### PR TITLE
Update pipeline for user_interactions changes

### DIFF
--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -27,7 +27,7 @@ def _split_by_user(df: pd.DataFrame) -> Dict[int, Dict[str, pd.DataFrame]]:
         positives = grp[(grp["playtime_forever"] > 0) | (grp["playtime_2weeks"] > 0) | (grp["wishlisted"])]
         if len(positives) < 20:
             continue
-        grp = grp.sort_values("last_played")
+        grp = grp.sample(frac=1, random_state=42)
         n = len(grp)
         idx_train_end = max(int(0.8 * n), 1)
         idx_val_end = max(int(0.9 * n), idx_train_end + 1)

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -44,14 +44,11 @@ def recommend(
             'wishlisted',
             'wishlist_priority',
             'date_added_to_wishlist',
-            'last_played',
         ]
         for col in required_cols:
             if col not in lib.columns:
                 if col == 'wishlisted':
                     lib[col] = False
-                elif col == 'last_played':
-                    lib[col] = pd.Timestamp.utcfromtimestamp(0)
                 else:
                     lib[col] = 0
         pos_mask = (

--- a/ml/pipeline/chunk1_loader.py
+++ b/ml/pipeline/chunk1_loader.py
@@ -56,8 +56,7 @@ def load_interactions_table(connection) -> pd.DataFrame:
     """
     query = """
         SELECT user_id, app_id, playtime_forever, playtime_2weeks,
-               wishlisted, wishlist_priority, date_added_to_wishlist,
-               last_played
+               wishlisted, wishlist_priority, date_added_to_wishlist
         FROM interactions
     """
     df = pd.read_sql(query, connection)

--- a/ml/pipeline/chunk7_user_profile.py
+++ b/ml/pipeline/chunk7_user_profile.py
@@ -37,13 +37,13 @@ def compute_user_meta_raw(user_id: int, interactions_df: pd.DataFrame, data_dir:
         user_tag_profile = global_tag_mean.copy()
 
     recent_cut = now - timedelta(days=30)
-    recent = interactions_df[(interactions_df['user_id']==user_id) & (interactions_df['last_played']>=recent_cut)]
-    recency = 0.0
-    for _, r in recent.iterrows():
-        d = (now - r['last_played']).days
-        play = 1 if (r['playtime_forever']>0 or r['playtime_2weeks']>0) else 0
-        wish = 1 if r['wishlisted'] else 0
-        recency += math.exp(-ALPHA*d)*(play + wish)
+    recent_play = interactions_df[
+        (interactions_df['user_id']==user_id) & (interactions_df['playtime_2weeks']>0)
+    ]
+    recent_wish = interactions_df[
+        (interactions_df['user_id']==user_id) & (interactions_df['date_added_to_wishlist']>=recent_cut)
+    ]
+    recency = float(len(recent_play) + len(recent_wish))
 
     user_meta_raw = np.concatenate([user_tag_profile, [recency]], axis=0)
     return user_tag_profile, recency, user_meta_raw


### PR DESCRIPTION
## Summary
- update loading of interactions data to drop the `last_played` column
- shuffle interactions when splitting train/val/test sets
- adapt user profile computation to use recent play and wishlist data instead of `last_played`
- simplify inference path for ad-hoc user libraries
- compile pipeline modules

## Testing
- `python -m py_compile ml/pipeline/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6850ea3faa94832fb1c1a5aaa11c9cba