### PR TITLE
Handle missing tags in PCA

### DIFF
--- a/ml/pipeline/chunk1_loader.py
+++ b/ml/pipeline/chunk1_loader.py
@@ -7,9 +7,12 @@ from .utils import save_json
 
 
 def load_tags_table(connection) -> Dict[str, int]:
-    df_tags = pd.read_sql('SELECT tag_id FROM steam_tag_summary', connection)
-    tag_ids = df_tags['tag_id'].unique().tolist()
-    tag_id_map = {tag_id: idx for idx, tag_id in enumerate(tag_ids)}
+    df_tags = pd.read_sql(
+        'SELECT tag_id FROM steam_tag_summary WHERE tag_id IS NOT NULL',
+        connection,
+    )
+    tag_ids = df_tags['tag_id'].dropna().astype(int).unique().tolist()
+    tag_id_map = {str(tag_id): idx for idx, tag_id in enumerate(tag_ids)}
     os.makedirs('ml/data', exist_ok=True)
     save_json(tag_id_map, 'ml/data/tag_id_map.json')
     return tag_id_map

--- a/ml/pipeline/chunk3_tags_pca.py
+++ b/ml/pipeline/chunk3_tags_pca.py
@@ -14,7 +14,11 @@ def run_tag_pca(games_df: pd.DataFrame) -> None:
     for row_idx, row in games_df.iterrows():
         tags = row['tags'] or []
         for tag_id, rank in tags:
-            idx = tag_id_map[str(tag_id)]
+            key = str(tag_id)
+            if key not in tag_id_map:
+                # Skip tags that are missing from the tag_id_map
+                continue
+            idx = tag_id_map[key]
             weight = (21 - rank) / 20.0
             T_raw_all[row_idx, idx] = weight
         app_ids.append(row['app_id'])


### PR DESCRIPTION
## Summary
- avoid KeyError in `chunk3_tags_pca` by ignoring tags missing from `tag_id_map`
- clean tag IDs before saving map to JSON

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686171deafd4832f925a44563f128322