### PR TITLE
Add progress tracking and flush output

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The remaining chunks provide utilities for user profiling, model architecture, t
 To execute the entire pipeline inside the ML container and train the model, run:
 
 ```bash
-docker compose --profile train up ml-train
+PYTHONUNBUFFERED=1 docker compose --profile train up --build ml-train
 ```
 
 This command runs `ml/pipeline/train_pipeline.py` which sequentially executes all pipeline chunks and trains the ranking model.

--- a/ml/pipeline/train_pipeline.py
+++ b/ml/pipeline/train_pipeline.py
@@ -1,30 +1,63 @@
 import os
+import time
 from .utils import get_current_utc_date
 import pandas as pd
 import mysql.connector
 
-from . import chunk1_loader, chunk2_structured, chunk3_tags_pca, chunk4_text_pca, chunk5_item_meta, chunk6_faiss, chunk10_train
+from . import (
+    chunk1_loader,
+    chunk2_structured,
+    chunk3_tags_pca,
+    chunk4_text_pca,
+    chunk5_item_meta,
+    chunk6_faiss,
+    chunk10_train,
+)
 
 
 def main():
+    start_time = time.time()
+    step = 0
+    total_steps = 7
+
+    def run_step(name, func):
+        """Execute *func* and print progress with timing and ETA."""
+        nonlocal step
+        step += 1
+        print(f"[{step}/{total_steps}] Starting {name}...", flush=True)
+        s = time.time()
+        result = func()
+        elapsed_step = time.time() - s
+        elapsed_total = time.time() - start_time
+        eta = (elapsed_total / step) * (total_steps - step)
+        print(
+            f"[{step}/{total_steps}] Completed {name} in {elapsed_step:.1f}s "
+            f"(elapsed {elapsed_total:.1f}s, ETA {eta:.1f}s)",
+            flush=True,
+        )
+        return result
+
     conn = mysql.connector.connect(
         host=os.getenv('MYSQL_HOST'),
         user=os.getenv('MYSQL_USER'),
         password=os.getenv('MYSQL_PASSWORD'),
         database=os.getenv('MYSQL_DATABASE'),
     )
-    chunk1_loader.main(conn)
+    run_step("chunk1", lambda: chunk1_loader.main(conn))
     conn.close()
 
     games_df = pd.read_pickle('ml/data/games_df.pkl')
-    chunk2_structured.structured_transform(games_df, get_current_utc_date())
-    chunk3_tags_pca.run_tag_pca(games_df)
-    chunk4_text_pca.run_text_pca(games_df)
-    chunk5_item_meta.run_item_meta_embedding()
-    chunk6_faiss.build_faiss_indices()
+    run_step("chunk2", lambda: chunk2_structured.structured_transform(games_df, get_current_utc_date()))
+    run_step("chunk3", lambda: chunk3_tags_pca.run_tag_pca(games_df))
+    run_step("chunk4", lambda: chunk4_text_pca.run_text_pca(games_df))
+    run_step("chunk5", chunk5_item_meta.run_item_meta_embedding)
+    run_step("chunk6", chunk6_faiss.build_faiss_indices)
 
     epochs = int(os.getenv('NUM_EPOCHS', '1'))
-    chunk10_train.train_model(num_epochs=epochs)
+    run_step("chunk10", lambda: chunk10_train.train_model(num_epochs=epochs))
+
+    total_elapsed = time.time() - start_time
+    print(f"Pipeline finished in {total_elapsed:.1f}s", flush=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- show progress timing info in `train_pipeline`
- instruct using unbuffered Python for docker training
- restore single quotes in `train_pipeline` and document `run_step`

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686177ced54c832f9aee4c69d0418537