### PR TITLE
Clean HTML from detailed_description

### DIFF
--- a/gatherer/gather-data.py
+++ b/gatherer/gather-data.py
@@ -38,6 +38,12 @@ tag_upserts: list[tuple[int, str, int]] = []
 # holds all reviews for batch upserts
 review_upserts: list[tuple[int,int,int,int]] = []
 
+# Utility to remove HTML tags from Steam API fields
+def strip_html(raw_html: str) -> str:
+    if not raw_html:
+        return ""
+    return BeautifulSoup(raw_html, "html.parser").get_text(" ", strip=True)
+
 # 1) Create two handlers: one for INFO→stdout, one for WARNING+→stderr
 stdout_handler = logging.StreamHandler(sys.stdout)
 stderr_handler = logging.StreamHandler(sys.stderr)
@@ -236,7 +242,8 @@ def store_game_details_in_db(new_ids_only: bool):
         recommendations_count = rec_data.get("total", 0)
 
         short_description = details.get("short_description", "")
-        detailed_description = details.get("detailed_description", "")
+        detailed_description_html = details.get("detailed_description", "")
+        detailed_description = strip_html(detailed_description_html)
 
         genres = ", ".join([g.get("description", "") for g in details.get("genres", []) if g.get("description")])
         categories = ", ".join([c.get("description", "") for c in details.get("categories", []) if c.get("description")])

--- a/ml/pipeline/chunk3_tags_pca.py
+++ b/ml/pipeline/chunk3_tags_pca.py
@@ -8,8 +8,26 @@ from .utils import load_json, save_numpy, save_torch
 def run_tag_pca(games_df: pd.DataFrame) -> None:
     tag_id_map = load_json('ml/data/tag_id_map.json')
     V = len(tag_id_map)
+    N = len(games_df)
     app_ids = []
-    T_raw_all = np.zeros((len(games_df), V), dtype=float)
+
+    # Compute document frequency for each tag
+    df_counts = np.zeros(V, dtype=int)
+    for tags in games_df['tags']:
+        if not tags:
+            continue
+        seen = set()
+        for tag_id, _ in tags:
+            key = str(tag_id)
+            if key in tag_id_map:
+                seen.add(tag_id_map[key])
+        for idx in seen:
+            df_counts[idx] += 1
+
+    # Smooth IDF as in sklearn: log((N + 1) / (df + 1)) + 1
+    idf = np.log((N + 1) / (df_counts + 1)) + 1.0
+
+    T_raw_all = np.zeros((N, V), dtype=float)
 
     for row_idx, row in games_df.iterrows():
         tags = row['tags'] or []
@@ -19,8 +37,8 @@ def run_tag_pca(games_df: pd.DataFrame) -> None:
                 # Skip tags that are missing from the tag_id_map
                 continue
             idx = tag_id_map[key]
-            weight = (21 - rank) / 20.0
-            T_raw_all[row_idx, idx] = weight
+            tf = (21 - rank) / 20.0
+            T_raw_all[row_idx, idx] = tf * idf[idx]
         app_ids.append(row['app_id'])
 
     pca = PCA(n_components=256)


### PR DESCRIPTION
## Summary
- strip HTML tags in the Steam `detailed_description` field when gathering data
- use TF-IDF weighting for tags with IDF smoothing

## Testing
- `python -m py_compile ml/pipeline/*.py`
- `python -m py_compile gatherer/gather-data.py`


------
https://chatgpt.com/codex/tasks/task_e_686205b0f0ec832f9f718a07cb2f9bd1