### PR TITLE
Align data paths and dynamic dimensions in ML pipeline

### DIFF
--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -52,17 +52,21 @@ def _sample_negative(user_pos: List[int], global_popular: List[int]) -> int:
     return int(np.random.choice(candidates))
 
 
-def train_model(num_epochs: int = 1, batch_size: int = 256) -> None:
-    interactions = pd.read_pickle("data/interactions_df.pkl")
+def train_model(num_epochs: int = 1, batch_size: int = 256, data_dir: str | None = None) -> None:
+    if data_dir is None:
+        data_dir = os.getenv("ML_DATA_DIR", "ml/data")
+    interactions = pd.read_pickle(os.path.join(data_dir, "interactions_df.pkl"))
     splits = _split_by_user(interactions)
     user_ids = sorted(splits.keys())
     user_id_map = build_id_to_index_map(user_ids)
-    save_json(user_id_map, "data/user_id_to_index.json")
-    app_id_to_index = load_json("data/app_id_to_meta_index.json")
-    global_popular = load_json("data/global_popular_games.json")
+    save_json(user_id_map, os.path.join(data_dir, "user_id_to_index.json"))
+    app_id_to_index = load_json(os.path.join(data_dir, "app_id_to_meta_index.json"))
+    global_popular = load_json(os.path.join(data_dir, "global_popular_games.json"))
+
+    tag_dim = load_numpy(os.path.join(data_dir, "T_pca_norm.npy")).shape[1]
 
     tables = EmbeddingTables(len(user_ids), len(app_id_to_index))
-    user_meta_fc = UserMetaFC()
+    user_meta_fc = UserMetaFC(tag_dim + 1)
     score_mlp = ScoreMLP()
 
     params = list(tables.user_emb.parameters()) + list(tables.item_emb.parameters())
@@ -71,7 +75,7 @@ def train_model(num_epochs: int = 1, batch_size: int = 256) -> None:
     steps_per_epoch = ceil(len(user_ids) / batch_size)
     scheduler = get_cosine_schedule_with_warmup(optimizer, steps_per_epoch, num_epochs * steps_per_epoch)
 
-    item_meta_embs = load_numpy("data/item_meta_embs.npy")
+    item_meta_embs = load_numpy(os.path.join(data_dir, "item_meta_embs.npy"))
 
     for epoch in range(num_epochs):
         np.random.shuffle(user_ids)
@@ -97,7 +101,7 @@ def train_model(num_epochs: int = 1, batch_size: int = 256) -> None:
                 pos_emb = tables.item_emb(torch.tensor([pos_idx]))
                 neg_emb = tables.item_emb(torch.tensor([neg_idx]))
 
-                _, _, meta_raw = compute_user_meta_raw(u, interactions)
+                _, _, meta_raw = compute_user_meta_raw(u, interactions, data_dir)
                 user_meta_emb = user_meta_fc(torch.tensor(meta_raw).float().unsqueeze(0))
 
                 pos_meta = torch.from_numpy(item_meta_embs[pos_idx]).float().unsqueeze(0)
@@ -119,9 +123,9 @@ def train_model(num_epochs: int = 1, batch_size: int = 256) -> None:
         print(f"epoch {epoch} loss {epoch_loss/steps_per_epoch:.4f}")
 
     tables.compute_means()
-    tables.save("data/emb_tables")
-    save_checkpoint(user_meta_fc.state_dict(), "data/user_meta_fc.pth")
-    save_checkpoint(score_mlp.state_dict(), "data/score_mlp.pth")
+    tables.save(os.path.join(data_dir, "emb_tables"))
+    save_checkpoint(user_meta_fc.state_dict(), os.path.join(data_dir, "user_meta_fc.pth"))
+    save_checkpoint(score_mlp.state_dict(), os.path.join(data_dir, "score_mlp.pth"))
 
 
 if __name__ == "__main__":

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -20,7 +20,8 @@ def recommend(
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     if data_dir is None:
         data_dir = os.getenv('ML_DATA_DIR', 'ml/data')
-    user_meta_fc = UserMetaFC().to(device)
+    tag_dim = load_numpy(os.path.join(data_dir, 'T_pca_norm.npy')).shape[1]
+    user_meta_fc = UserMetaFC(tag_dim + 1).to(device)
     score_mlp = ScoreMLP().to(device)
     user_meta_fc.load_state_dict(load_torch(os.path.join(data_dir, 'user_meta_fc.pth'), device))
     score_mlp.load_state_dict(load_torch(os.path.join(data_dir, 'score_mlp.pth'), device))

--- a/ml/pipeline/chunk5_item_meta.py
+++ b/ml/pipeline/chunk5_item_meta.py
@@ -8,9 +8,9 @@ from .utils import load_numpy, save_numpy, save_torch, save_json
 
 
 class ItemMetaFC(nn.Module):
-    def __init__(self):
+    def __init__(self, input_dim: int):
         super().__init__()
-        self.fc1 = nn.Linear(522, 512)
+        self.fc1 = nn.Linear(input_dim, 512)
         self.bn1 = nn.BatchNorm1d(512)
         self.fc2 = nn.Linear(512, 256)
         self.bn2 = nn.BatchNorm1d(256)
@@ -43,7 +43,7 @@ def run_item_meta_embedding() -> None:
     item_meta_raw = np.concatenate([structured_norm, T_pca_norm, E_pca], axis=1)
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    model = ItemMetaFC().to(device)
+    model = ItemMetaFC(item_meta_raw.shape[1]).to(device)
     model.eval()
     with torch.no_grad():
         x = torch.from_numpy(item_meta_raw).float().to(device)

--- a/ml/pipeline/chunk7_user_profile.py
+++ b/ml/pipeline/chunk7_user_profile.py
@@ -14,9 +14,9 @@ from .utils import (
 ALPHA = compute_alpha(30)
 
 
-def compute_user_meta_raw(user_id: int, interactions_df: pd.DataFrame, data_dir: str = None):
+def compute_user_meta_raw(user_id: int, interactions_df: pd.DataFrame, data_dir: str | None = None):
     if data_dir is None:
-        data_dir = os.getenv("ML_DATA_DIR", "data")
+        data_dir = os.getenv("ML_DATA_DIR", "ml/data")
     T_pca_norm = load_numpy(os.path.join(data_dir, 'T_pca_norm.npy'))
     app_ids = load_numpy(os.path.join(data_dir, 'structured_app_ids.npy')).tolist()
     app_id_to_index = build_id_to_index_map(app_ids)

--- a/ml/pipeline/chunk9_model.py
+++ b/ml/pipeline/chunk9_model.py
@@ -4,9 +4,9 @@ import torch.nn.functional as F
 
 
 class UserMetaFC(nn.Module):
-    def __init__(self):
+    def __init__(self, input_dim: int):
         super().__init__()
-        self.fc1 = nn.Linear(257, 256)
+        self.fc1 = nn.Linear(input_dim, 256)
         self.bn1 = nn.BatchNorm1d(256)
         self.fc2 = nn.Linear(256, 128)
 


### PR DESCRIPTION
## Summary
- Default to `ml/data` for pipeline resources and allow override via `ML_DATA_DIR`
- Adapt `ItemMetaFC` and `UserMetaFC` to infer input sizes from PCA outputs
- Ensure training and inference modules use the new dynamic dimensions and shared data directory

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9ddfe5948832f9c71f418c1be3734