### PR TITLE
Handle missing interactions dataframe and dedupe recommendations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
     command: uvicorn recommend_games:app --host 0.0.0.0 --port 8001
     working_dir: /app/ml
     environment:
-      - ML_DATA_DIR=/app/data
+      - ML_DATA_DIR=/app/ml/data
       - API_KEY=${API_KEY}
     volumes:
       - .:/app

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -10,6 +10,20 @@ from .chunk8_embeddings import EmbeddingTables
 from .chunk7_user_profile import compute_user_meta_raw
 
 
+def _filter_unique(candidates, K, exclude_ids):
+    seen = set(int(x) for x in exclude_ids)
+    results = []
+    for c in candidates:
+        app_id = int(c['app_id']) if isinstance(c, dict) else int(c)
+        if app_id in seen:
+            continue
+        seen.add(app_id)
+        results.append(c)
+        if len(results) >= K:
+            break
+    return results
+
+
 def recommend(
     user_id: int,
     interactions_df,
@@ -62,10 +76,10 @@ def recommend(
             user_df = lib
         else:
             popular = load_json(os.path.join(data_dir, 'global_popular_games.json'))
-            return popular[:K]
+            return _filter_unique(popular, K, lib['app_id'].astype(int).tolist())
     elif user_df.empty:
         popular = load_json(os.path.join(data_dir, 'global_popular_games.json'))
-        return popular[:K]
+        return _filter_unique(popular, K, [])
 
     pos_mask_df = (
         (user_df['playtime_forever'] > 0)
@@ -74,7 +88,7 @@ def recommend(
     )
     if pos_mask_df.sum() < 20:
         popular = load_json(os.path.join(data_dir, 'global_popular_games.json'))
-        return popular[:K]
+        return _filter_unique(popular, K, user_df['app_id'].astype(int).tolist())
 
     _, _, user_meta_raw = compute_user_meta_raw(user_id, user_df, data_dir)
     with torch.no_grad():
@@ -121,5 +135,4 @@ def recommend(
             scores.append(s.item())
 
     ranked = [x for _, x in sorted(zip(scores, candidate_ids), key=lambda t: t[0], reverse=True)]
-    return ranked[:K]
-
+    return _filter_unique(ranked, K, user_df['app_id'].astype(int).tolist())

--- a/ml/recommend_games.py
+++ b/ml/recommend_games.py
@@ -17,7 +17,25 @@ logging.basicConfig(
 )
 
 DATA_DIR = os.getenv("ML_DATA_DIR", "ml/data")
-INTERACTIONS_DF = pd.read_pickle(os.path.join(DATA_DIR, "interactions_df.pkl"))
+_interactions_path = os.path.join(DATA_DIR, "interactions_df.pkl")
+if os.path.exists(_interactions_path):
+    INTERACTIONS_DF = pd.read_pickle(_interactions_path)
+else:
+    logging.warning(
+        "interactions_df.pkl not found at %s. Using empty interactions dataframe.",
+        _interactions_path,
+    )
+    INTERACTIONS_DF = pd.DataFrame(
+        columns=[
+            "user_id",
+            "app_id",
+            "playtime_forever",
+            "playtime_2weeks",
+            "wishlisted",
+            "wishlist_priority",
+            "date_added_to_wishlist",
+        ]
+    )
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- gracefully handle missing `interactions_df.pkl` by creating empty dataframe and logging a warning
- point recommender service to the `ml/data` directory
- ensure recommendation results are unique by filtering out duplicates and already owned games

## Testing
- `python -m py_compile ml/recommend_games.py ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ace64b8c28832f8acb53b05aa3bf4b