### PR TITLE
Fix price overview type error in gatherer

### DIFF
--- a/gatherer/gather-data.py
+++ b/gatherer/gather-data.py
@@ -210,8 +210,9 @@ def store_game_details_in_db(new_ids_only: bool):
         name = details.get("name", "")
         is_free = 1 if details.get("is_free", False) else 0
 
-        # Extract price overview
-        price_overview = details.get("price_overview", {})
+        # Extract price overview and store as JSON if present
+        price_overview_data = details.get("price_overview")
+        price_overview = json.dumps(price_overview_data) if price_overview_data else None
 
         release_date_info = details.get("release_date", {})
         coming_soon = 1 if release_date_info.get("coming_soon", False) else 0
@@ -262,7 +263,7 @@ def store_game_details_in_db(new_ids_only: bool):
             short_description, detailed_description, genres, categories, developer, publisher, platforms,
             recommendations, raw_json, header_image, screenshot1, screenshot2, screenshot3, screenshot4
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON DUPLICATE KEY UPDATE
             name = VALUES(name), coming_soon = VALUES(coming_soon), release_date = VALUES(release_date),
             price_overview = VALUES(price_overview), is_free = VALUES(is_free), short_description = VALUES(short_description),


### PR DESCRIPTION
## Summary
- Serialize `price_overview` to JSON before inserting into `steam_game_details`
- Correct placeholder count in upsert SQL to match column list

## Testing
- `python -m py_compile gatherer/gather-data.py`
- `MYSQL_HOST=localhost MYSQL_USER=root MYSQL_PASSWORD=test MYSQL_DATABASE=test API_KEY=dummy python gatherer/gather-data.py --type gather-new-games-info` *(fails: Can't connect to MySQL server on 'localhost:3306')*


------
https://chatgpt.com/codex/tasks/task_e_68acf815d680832fa5fdcf5ceb1bb9e0