### PR TITLE
Serialize dict fields before DB upsert in gatherer

### DIFF
--- a/gatherer/gather-data.py
+++ b/gatherer/gather-data.py
@@ -211,7 +211,9 @@ def store_game_details_in_db(new_ids_only: bool):
         is_free = 1 if details.get("is_free", False) else 0
 
         # Extract price overview
-        price_overview = details.get("price_overview", {})
+        price_overview = details.get("price_overview")
+        if isinstance(price_overview, (dict, list)):
+            price_overview = json.dumps(price_overview)
 
         release_date_info = details.get("release_date", {})
         coming_soon = 1 if release_date_info.get("coming_soon", False) else 0
@@ -262,7 +264,7 @@ def store_game_details_in_db(new_ids_only: bool):
             short_description, detailed_description, genres, categories, developer, publisher, platforms,
             recommendations, raw_json, header_image, screenshot1, screenshot2, screenshot3, screenshot4
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON DUPLICATE KEY UPDATE
             name = VALUES(name), coming_soon = VALUES(coming_soon), release_date = VALUES(release_date),
             price_overview = VALUES(price_overview), is_free = VALUES(is_free), short_description = VALUES(short_description),
@@ -274,10 +276,31 @@ def store_game_details_in_db(new_ids_only: bool):
             screenshot2 = VALUES(screenshot2), screenshot3 = VALUES(screenshot3), screenshot4 = VALUES(screenshot4)
         """
         vals = (
-            app_id, name, coming_soon, release_date, price_overview, is_free,
-            short_description, detailed_description, genres, categories, developers, publishers, platforms,
-            recommendations_count, raw_data_json, header_image, screenshot1, screenshot2, screenshot3, screenshot4
+            app_id,
+            name,
+            coming_soon,
+            release_date,
+            price_overview,
+            is_free,
+            short_description,
+            detailed_description,
+            genres,
+            categories,
+            developers,
+            publishers,
+            platforms,
+            recommendations_count,
+            raw_data_json,
+            header_image,
+            screenshot1,
+            screenshot2,
+            screenshot3,
+            screenshot4,
         )
+
+        if any(isinstance(v, (dict, list)) for v in vals):
+            logging.error(f"Unserializable field detected for app_id={app_id}")
+            continue
 
         try:
             cursor.execute(upsert_sql, vals)


### PR DESCRIPTION
## Summary
- JSON-encode `price_overview` and full game detail payload before database insert
- Guard against dict/list values slipping into the upsert parameters

## Testing
- `python -m py_compile gatherer/gather-data.py`
- `MYSQL_HOST=localhost MYSQL_USER=root MYSQL_PASSWORD=test MYSQL_DATABASE=test API_KEY=dummy python gatherer/gather-data.py --type gather-new-games-info` *(fails: Can't connect to MySQL server on 'localhost:3306')*


------
https://chatgpt.com/codex/tasks/task_e_68acf815d680832fa5fdcf5ceb1bb9e0