### PR TITLE
feat: add item meta diagnostics and schema

### DIFF
--- a/ml/pipeline/chunk5_item_meta.py
+++ b/ml/pipeline/chunk5_item_meta.py
@@ -39,6 +39,13 @@ def run_item_meta_embedding() -> None:
     # Load tag/text embeddings and their app_id arrays
     T_pca_norm = load_numpy('ml/data/T_pca_norm.npy')
     E_qwen3 = load_numpy('ml/data/E_qwen3.npy')
+    print(f"E_qwen3 loaded with shape {E_qwen3.shape} and dtype {E_qwen3.dtype}")
+    e_norms = np.linalg.norm(E_qwen3, axis=1)
+    zero_norms = np.sum(e_norms == 0)
+    if zero_norms:
+        print(f"E_qwen3 zero-norm rows: {zero_norms}")
+    e_norms[e_norms == 0] = 1
+    E_qwen3 = E_qwen3 / e_norms[:, None]
     tag_app_ids = load_numpy('ml/data/tag_pca_app_ids.npy')
 
     tag_idx_map = {int(aid): idx for idx, aid in enumerate(tag_app_ids)}
@@ -68,8 +75,12 @@ def run_item_meta_embedding() -> None:
     T_pca_norm = np.array(T_f)
     E_qwen3 = np.array(E_f)
     app_ids = np.array(app_ids_f)
+    print(f"X_structured dims: {structured.shape}")
+    print(f"T_pca_norm dims: {T_pca_norm.shape}")
+    print(f"E_qwen3 dims: {E_qwen3.shape}")
     # X_structured is already scaled; concatenate directly with tag PCs and text embeddings
     item_meta_raw = np.concatenate([structured, T_pca_norm, E_qwen3], axis=1)
+    print(f"item_meta_raw shape: {item_meta_raw.shape}")
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     model = ItemMetaFC(item_meta_raw.shape[1]).to(device)
@@ -77,11 +88,22 @@ def run_item_meta_embedding() -> None:
     with torch.no_grad():
         x = torch.from_numpy(item_meta_raw).float().to(device)
         embs = model(x)
+    print(f"ItemMetaFC output shape: {embs.shape}")
     embs_np = embs.cpu().numpy().astype('float32')
     os.makedirs('ml/data', exist_ok=True)
     save_numpy(embs_np, 'ml/data/item_meta_embs.npy')
     save_torch(model.state_dict(), 'ml/data/item_meta_fc.pth')
     mapping = {int(app_id): int(idx) for idx, app_id in enumerate(app_ids)}
     save_json(mapping, 'ml/data/app_id_to_meta_index.json')
-    print('✅ Chunk 5 item meta embeddings saved')
+    schema = {
+        'structured': int(structured.shape[1]),
+        'tag': int(T_pca_norm.shape[1]),
+        'text': int(E_qwen3.shape[1]),
+        'final': int(embs_np.shape[1]),
+    }
+    print(f"Schema: {schema}")
+    save_json(schema, 'ml/data/item_meta_schema.json')
+    print(
+        f"✅ Processed {len(app_ids)} items. Outputs saved to ml/data/"
+    )
 


### PR DESCRIPTION
## Summary
- add shape/dtype logging and row-wise normalization for E_qwen3 embeddings
- report shapes throughout item metadata pipeline and final ItemMetaFC output
- generate and save item metadata schema alongside embeddings

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8f938b8d0832f9dc1d33fd2ad6466