### PR TITLE
Fix Steam data encoding in gatherer

### DIFF
--- a/gatherer/gather-data.py
+++ b/gatherer/gather-data.py
@@ -21,11 +21,16 @@ for var in required_vars:
         raise EnvironmentError(f"Missing required environment variable: {var}")
     
 # ---- MySQL CONNECTION ----
+# MySQL tends to default to ``latin1`` which can corrupt extended
+# characters when writing descriptions.  Force ``utf8mb4`` so text
+# scraped from Steam is stored losslessly.
 conn = mysql.connector.connect(
     host=os.environ["MYSQL_HOST"],
     user=os.environ["MYSQL_USER"],
     passwd=os.environ["MYSQL_PASSWORD"],
-    database=os.environ["MYSQL_DATABASE"]
+    database=os.environ["MYSQL_DATABASE"],
+    charset="utf8mb4",
+    use_unicode=True,
 )
 cursor = conn.cursor()
 


### PR DESCRIPTION
## Summary
- force utf8mb4 charset on MySQL connection to prevent gibberish text when storing Steam descriptions

## Testing
- `python -m py_compile gatherer/gather-data.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba1fef0148832f8565a3f77320b0a0