### PR TITLE
Use local Qwen model cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,8 @@ services:
       context: ./ml
       dockerfile: Dockerfile
     env_file: .env
+    environment:
+      - QWEN3_MODEL_DIR=/app/ml/models/Qwen3-Embedding-4B
     depends_on:
       - mysql
     networks:

--- a/ml/pipeline/chunk4_text_embeddings.py
+++ b/ml/pipeline/chunk4_text_embeddings.py
@@ -20,11 +20,16 @@ def embed_texts(
 
     os.environ.setdefault("TOKENIZERS_PARALLELISM", "true")
 
-    model_id = "Qwen/Qwen3-Embedding-4B"
-    tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
-    model = AutoModel.from_pretrained(
-        model_id,
+    model_dir = os.getenv("QWEN3_MODEL_DIR", "ml/models/Qwen3-Embedding-4B")
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_dir,
         trust_remote_code=True,
+        local_files_only=True,
+    )
+    model = AutoModel.from_pretrained(
+        model_dir,
+        trust_remote_code=True,
+        local_files_only=True,
         torch_dtype=torch.float16 if device.startswith("cuda") else torch.float32,
         attn_implementation="sdpa",
     ).to(device)


### PR DESCRIPTION
## Summary
- load Qwen3 tokenizer and model from a locally downloaded directory
- expose QWEN3_MODEL_DIR env var in docker-compose for ml-train service

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68baf3b6f9fc832f83c7c3e89bd13cc2