### PR TITLE
Improve Qwen3 embedding memory handling

### DIFF
--- a/ml/pipeline/chunk4_text_embeddings.py
+++ b/ml/pipeline/chunk4_text_embeddings.py
@@ -1,9 +1,11 @@
 import os
 import time
 from typing import List
+import contextlib
 import numpy as np
 import pandas as pd
 import torch
+from torch.utils.data import DataLoader, Dataset
 from transformers import AutoModel, AutoTokenizer
 from .utils import save_numpy
 
@@ -13,10 +15,14 @@ def embed_texts(
     device: str = "cpu",
     short_max_length: int = 96,
     long_max_length: int = 1024,
+    batch_size: int = 8,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute short and long text embeddings using Qwen3 with batching and logs."""
 
     os.environ.setdefault("TOKENIZERS_PARALLELISM", "true")
+    if device.startswith("cuda"):
+        # Reduce allocator fragmentation when repeatedly allocating large tensors
+        os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
     model_dir = os.getenv("QWEN3_MODEL_DIR", "ml/models/Qwen3-Embedding-4B")
     tokenizer = AutoTokenizer.from_pretrained(
@@ -28,7 +34,7 @@ def embed_texts(
         model_dir,
         trust_remote_code=True,
         local_files_only=True,
-        torch_dtype=torch.float16 if device.startswith("cuda") else torch.float32,
+        dtype=torch.float16,
 
         attn_implementation="sdpa",
     ).to(device)
@@ -39,59 +45,94 @@ def embed_texts(
         torch.backends.cuda.enable_math_sdp(True)
         torch.set_float32_matmul_precision("high")
 
-    short_texts: List[str] = (games_df["short_description"].fillna("").tolist())
-    long_texts: List[str] = (games_df["long_description"].fillna("").tolist())
+    short_texts: List[str] = games_df["short_description"].fillna("").tolist()
+    long_texts: List[str] = games_df["long_description"].fillna("").tolist()
+
+    class TextDataset(Dataset):
+        def __init__(self, shorts: List[str], longs: List[str]) -> None:
+            self.shorts = shorts
+            self.longs = longs
+
+        def __len__(self) -> int:  # pragma: no cover - trivial
+            return len(self.shorts)
+
+        def __getitem__(self, idx: int) -> tuple[str, str]:  # pragma: no cover - trivial
+            return self.shorts[idx], self.longs[idx]
+
+    dataset = TextDataset(short_texts, long_texts)
+
+    def collate(batch: list[tuple[str, str]]) -> tuple[dict, dict]:
+        batch_short, batch_long = zip(*batch)
+        toks_short = tokenizer(
+            list(batch_short),
+            return_tensors="pt",
+            truncation=True,
+            padding=True,
+            pad_to_multiple_of=8,
+            max_length=short_max_length,
+        )
+        toks_long = tokenizer(
+            list(batch_long),
+            return_tensors="pt",
+            truncation=True,
+            padding=True,
+            pad_to_multiple_of=8,
+            max_length=long_max_length,
+        )
+        return toks_short, toks_long
+
+    loader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        collate_fn=collate,
+        pin_memory=device.startswith("cuda"),
+    )
 
     embeddings_short: List[np.ndarray] = []
     embeddings_long: List[np.ndarray] = []
     total_tokens = 0
-    batch_size = 64
     log_every = 80
     start_total = time.time()
 
-    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.float16):
-        for i in range(0, len(games_df), batch_size):
-            batch_short = short_texts[i : i + batch_size]
-            batch_long = long_texts[i : i + batch_size]
-
-            toks_short = tokenizer(
-                batch_short,
-                return_tensors="pt",
-                truncation=True,
-                padding=True,
-                pad_to_multiple_of=8,
-                max_length=short_max_length,
-            )
-            toks_long = tokenizer(
-                batch_long,
-                return_tensors="pt",
-                truncation=True,
-                padding=True,
-                pad_to_multiple_of=8,
-                max_length=long_max_length,
-            )
-            toks_short = {k: v.contiguous().to(device, non_blocking=True) for k, v in toks_short.items()}
-            toks_long = {k: v.contiguous().to(device, non_blocking=True) for k, v in toks_long.items()}
-
+    autocast_ctx = (
+        torch.autocast(device_type="cuda", dtype=torch.float16)
+        if device.startswith("cuda")
+        else contextlib.nullcontext()
+    )
+    with torch.inference_mode(), autocast_ctx:
+        for batch_idx, (toks_short, toks_long) in enumerate(loader, 1):
             batch_start = time.time()
+
+            toks_short = {k: v.contiguous().to(device, non_blocking=True) for k, v in toks_short.items()}
             out_short = model(**toks_short)
-            out_long = model(**toks_long)
             mask_s = toks_short["attention_mask"].unsqueeze(-1)
             emb_short = (out_short.last_hidden_state * mask_s).sum(dim=1) / mask_s.sum(dim=1).clamp(min=1)
+            embeddings_short.append(emb_short.float().cpu().numpy())
+            num_tokens_short = int(toks_short["attention_mask"].sum().item())
+            del out_short, emb_short, mask_s, toks_short
+            if device.startswith("cuda"):
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+
+            toks_long = {k: v.contiguous().to(device, non_blocking=True) for k, v in toks_long.items()}
+            out_long = model(**toks_long)
             mask_l = toks_long["attention_mask"].unsqueeze(-1)
             emb_long = (out_long.last_hidden_state * mask_l).sum(dim=1) / mask_l.sum(dim=1).clamp(min=1)
-            batch_time = time.time() - batch_start
+            embeddings_long.append(emb_long.float().cpu().numpy())
+            num_tokens_long = int(toks_long["attention_mask"].sum().item())
+            del out_long, emb_long, mask_l, toks_long
+            if device.startswith("cuda"):
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
 
-            num_tokens = int(toks_short["attention_mask"].sum().item() + toks_long["attention_mask"].sum().item())
+            batch_time = time.time() - batch_start
+            num_tokens = num_tokens_short + num_tokens_long
             total_tokens += num_tokens
             tok_per_sec = num_tokens / batch_time if batch_time > 0 else float("inf")
 
-            embeddings_short.append(emb_short.float().cpu().numpy())
-            embeddings_long.append(emb_long.float().cpu().numpy())
-
-            batch_idx = i // batch_size + 1
             if batch_idx % log_every == 0 or batch_idx == 1:
-                processed = min(i + batch_size, len(games_df))
+                processed = min(batch_idx * batch_size, len(games_df))
                 remaining = len(games_df) - processed
                 print(
                     f"Batch {batch_idx}: processed {processed}/{len(games_df)} rows, "
@@ -109,6 +150,7 @@ def run_text_embeddings(
     games_df: pd.DataFrame,
     short_max_length: int = 96,
     long_max_length: int = 1024,
+    batch_size: int = 8,
 ) -> None:
     """Generate and store separate Qwen3 text embeddings."""
 
@@ -118,6 +160,7 @@ def run_text_embeddings(
         device,
         short_max_length=short_max_length,
         long_max_length=long_max_length,
+        batch_size=batch_size,
     )
 
     os.makedirs("ml/data", exist_ok=True)


### PR DESCRIPTION
## Summary
- allow configurable batch size for Qwen3 embedding DataLoader to lower per-step memory use
- synchronize CUDA before emptying cache to fully release memory between short and long passes

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bafba34cd4832f95a3b17581d784fd