### PR TITLE
Make Qwen3 model optional in ML Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,16 @@ To resume from a specific chunk, set the `START_CHUNK` environment variable. For
 set START_CHUNK=5 && set PYTHONUNBUFFERED=1 && docker compose --profile train up --build ml-train
 ```
 
+### Optional Qwen3 model
+
+The ML image bundles `ml/models/Qwen3-Embedding-4B` so that chunks 1–4 run out of the
+box. To skip this large directory (useful when starting at chunk 5) build with:
+
+```bash
+docker build -f ml/Dockerfile --build-arg INCLUDE_QWEN=false ml
+```
+
+The `INCLUDE_QWEN` build argument deletes only the Qwen3 folder, leaving any other
+subdirectories under `ml/models` intact. You can still mount the model at runtime and
+point `QWEN3_MODEL_DIR` to its location if needed.
+

--- a/ml/Dockerfile
+++ b/ml/Dockerfile
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 
+ARG INCLUDE_QWEN=true
+
 WORKDIR /app
 
 # Install Python and basic tools
@@ -21,5 +23,11 @@ RUN pip install fastapi uvicorn scikit-learn torch joblib
 
 # Now copy your actual code (only if needed)
 COPY . .
+
+# Optionally drop the heavy Qwen3 embedding model to speed up builds when
+# starting from later chunks.
+RUN if [ "$INCLUDE_QWEN" != "true" ]; then \
+      rm -rf models/Qwen3-Embedding-4B; \
+    fi
 
 # Entrypoint is defined by docker-compose


### PR DESCRIPTION
## Summary
- Include model directories in build context and expose `INCLUDE_QWEN` arg to optionally remove Qwen3-Embedding-4B from the image
- Document how to skip bundling Qwen3 and still mount it at runtime
- Remove unused `ml/.dockerignore` file

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb6684569c832f9a14da63e5018cfd