### PR TITLE
refactor: document and harden faiss index build

### DIFF
--- a/ml/pipeline/chunk6_faiss.py
+++ b/ml/pipeline/chunk6_faiss.py
@@ -2,37 +2,37 @@ import os
 import json
 import numpy as np
 import faiss
+
 from .utils import load_numpy, save_json
 
 
 def build_faiss_indices() -> None:
+    """Build FAISS indices for tag and item metadata embeddings.
+
+    The function aligns tag-based PCA embeddings and metadata-based embeddings
+    on a common ``app_id`` ordering, then writes cosine-similarity FAISS indices
+    (inner-product over L2-normalized vectors) along with mappings from index
+    positions back to ``app_id`` values.
+    """
+
+    os.makedirs('ml/data', exist_ok=True)
+
     # Load meta embeddings and alignment mapping
-    meta_embs = load_numpy('ml/data/item_meta_embs.npy').astype('float32')
+    meta_embs = load_numpy('ml/data/item_meta_embs.npy').astype(np.float32)
     with open('ml/data/app_id_to_meta_index.json', 'r', encoding='utf-8') as f:
         app_id_to_meta_index = {int(k): int(v) for k, v in json.load(f).items()}
 
-    # Build ordered app_id list by meta index
-    max_idx = max(app_id_to_meta_index.values()) if app_id_to_meta_index else -1
-    app_ids_ordered = [None] * (max_idx + 1)
-    for aid, idx in app_id_to_meta_index.items():
-        if 0 <= idx <= max_idx:
-            app_ids_ordered[idx] = int(aid)
+    meta_app_ids = np.array(list(app_id_to_meta_index.keys()), dtype=int)
+    meta_indices = np.array(list(app_id_to_meta_index.values()), dtype=int)
 
-    # Load tag PCA and align to the same app_id ordering
-    T_pca_all = load_numpy('ml/data/T_pca_norm.npy').astype('float32')
-    tag_app_ids = load_numpy('ml/data/tag_pca_app_ids.npy')
-    tag_idx_map = {int(a): i for i, a in enumerate(tag_app_ids)}
-    T_f = []
-    kept_app_ids = []
-    for aid in app_ids_ordered:
-        if aid is None:
-            continue
-        t_idx = tag_idx_map.get(int(aid))
-        if t_idx is None:
-            continue
-        T_f.append(T_pca_all[t_idx])
-        kept_app_ids.append(int(aid))
-    T_final = np.array(T_f, dtype='float32')
+    # Load tag PCA embeddings and align using intersection of app_ids
+    T_pca_all = load_numpy('ml/data/T_pca_norm.npy').astype(np.float32)
+    tag_app_ids = load_numpy('ml/data/tag_pca_app_ids.npy').astype(int)
+    common_app_ids, tag_idx, meta_pos = np.intersect1d(
+        tag_app_ids, meta_app_ids, return_indices=True
+    )
+    T_final = T_pca_all[tag_idx]
+    kept_app_ids = common_app_ids.astype(int).tolist()
 
     # Build tags FAISS index
     index_tags = faiss.IndexFlatIP(T_final.shape[1])
@@ -40,19 +40,17 @@ def build_faiss_indices() -> None:
     faiss.write_index(index_tags, 'ml/data/faiss_tags.index')
     save_json(kept_app_ids, 'ml/data/index_to_app_id_tags.json')
 
-    # Normalize and build meta FAISS index (match kept_app_ids length)
-    meta_kept = []
-    for aid in kept_app_ids:
-        idx = app_id_to_meta_index.get(int(aid))
-        if idx is not None and idx < len(meta_embs):
-            meta_kept.append(meta_embs[idx])
-    meta_kept = np.array(meta_kept, dtype='float32')
-    norms = np.linalg.norm(meta_kept, axis=1, keepdims=True)
+    # Normalize and build metadata FAISS index
+    meta_selected = meta_embs[meta_indices[meta_pos]]
+    norms = np.linalg.norm(meta_selected, axis=1, keepdims=True)
     norms[norms == 0] = 1e-6
-    meta_norm = meta_kept / norms
+    meta_norm = meta_selected / norms
     index_meta = faiss.IndexFlatIP(meta_norm.shape[1])
-    index_meta.add(meta_norm.astype('float32'))
+    index_meta.add(meta_norm)
+    if T_final.shape[0] != meta_norm.shape[0]:
+        raise ValueError('Tag and meta arrays differ in length; alignment failed.')
     faiss.write_index(index_meta, 'ml/data/faiss_meta.index')
     save_json(kept_app_ids, 'ml/data/index_to_app_id_meta.json')
+
     print('✅ Chunk 6 FAISS indices saved')
 


### PR DESCRIPTION
## Summary
- document FAISS index builder and ensure output directory exists
- validate meta/tag alignment and clean up dtype handling
- vectorize tag/meta alignment with numpy intersect

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb65340d94832f9cfbf38172375f14