### PR TITLE
Add single-chunk run option to ML pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@ To resume from a specific chunk, set the `START_CHUNK` environment variable. For
 set START_CHUNK=5 && set PYTHONUNBUFFERED=1 && docker compose --profile train up --build ml-train
 ```
 
+To run only a single chunk, use the `RUN_CHUNK` environment variable. For example, to run just chunk 3:
+
+```bash
+set RUN_CHUNK=3 && set PYTHONUNBUFFERED=1 && docker compose --profile train up --build ml-train
+```
+
+If both `RUN_CHUNK` and `START_CHUNK` are provided, only `RUN_CHUNK` is honored.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     gpus: all
     profiles: ["train"]
     working_dir: /app
-    command: python -m ml.pipeline.train_pipeline --start ${START_CHUNK:-1}
+    command: python -m ml.pipeline.train_pipeline ${RUN_CHUNK:+--chunk $RUN_CHUNK} --start ${START_CHUNK:-1}
       
   recommender:
     build:

--- a/ml/pipeline/train_pipeline.py
+++ b/ml/pipeline/train_pipeline.py
@@ -29,6 +29,12 @@ def main():
         ),
     )
     parser.add_argument(
+        "--chunk",
+        type=int,
+        default=None,
+        help="run only the specified chunk (1-6 or 10)",
+    )
+    parser.add_argument(
         "--epochs",
         type=int,
         default=None,
@@ -73,22 +79,30 @@ def main():
         ("chunk10", lambda: chunk10_train.train_model(num_epochs=epochs)),
     ]
 
-    # Determine starting chunk and slice the remaining steps
-    start_chunk = max(1, int(args.start))
-
+    # Determine which chunk(s) to run
     # Map chunk numbers (1-6,10) to index positions in ``steps``
     chunk_map = {
         int(name.replace("chunk", "")): idx
         for idx, (name, _) in enumerate(steps, start=1)
     }
     allowed = set(chunk_map.keys())
-    if start_chunk not in allowed:
-        raise SystemExit(
-            f"Invalid --start {start_chunk}. Allowed chunks: {sorted(allowed)}"
-        )
 
-    start_idx = chunk_map[start_chunk]
-    steps_to_run = steps[start_idx - 1 :]
+    if args.chunk is not None:
+        run_chunk = max(1, int(args.chunk))
+        if run_chunk not in allowed:
+            raise SystemExit(
+                f"Invalid --chunk {run_chunk}. Allowed chunks: {sorted(allowed)}"
+            )
+        start_idx = chunk_map[run_chunk]
+        steps_to_run = [steps[start_idx - 1]]
+    else:
+        start_chunk = max(1, int(args.start))
+        if start_chunk not in allowed:
+            raise SystemExit(
+                f"Invalid --start {start_chunk}. Allowed chunks: {sorted(allowed)}"
+            )
+        start_idx = chunk_map[start_chunk]
+        steps_to_run = steps[start_idx - 1 :]
 
     total_steps = len(steps_to_run)
 


### PR DESCRIPTION
## Summary
- support running a single pipeline chunk via new `--chunk` argument
- expose `RUN_CHUNK` env var in docker-compose to forward the option
- document how to run only one chunk and precedence over `START_CHUNK`

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca87eae34832f99130f54c6fba9fe