### PR TITLE
feat: enhance tag embeddings with idf and pmi

### DIFF
--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -76,7 +76,7 @@ def train_model(
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    tag_dim = load_numpy(os.path.join(data_dir, "T_pca_norm.npy")).shape[1]
+    tag_dim = load_numpy(os.path.join(data_dir, "tag_game_emb.npy")).shape[1]
 
     tables = EmbeddingTables(len(user_ids), len(app_id_to_index))
     tables.user_emb = tables.user_emb.to(device)

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -53,7 +53,7 @@ def recommend(
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     if data_dir is None:
         data_dir = os.getenv('ML_DATA_DIR', 'ml/data')
-    tag_dim = load_numpy(os.path.join(data_dir, 'T_pca_norm.npy')).shape[1]
+    tag_dim = load_numpy(os.path.join(data_dir, 'tag_game_emb.npy')).shape[1]
     user_meta_fc = UserMetaFC(tag_dim + 1).to(device)
     score_mlp = ScoreMLP().to(device)
     user_meta_fc.load_state_dict(load_torch(os.path.join(data_dir, 'user_meta_fc.pth'), device))

--- a/ml/pipeline/chunk3_tags_pca.py
+++ b/ml/pipeline/chunk3_tags_pca.py
@@ -1,80 +1,196 @@
 import os
+import math
+import json
+from itertools import combinations
+
 import numpy as np
 import pandas as pd
 from sklearn.decomposition import TruncatedSVD
 from scipy import sparse
-from .utils import load_json, save_numpy, save_torch
+
+from .utils import load_json, save_numpy, save_torch, save_json
 
 
-def run_tag_pca(games_df: pd.DataFrame, dim: int = 128, sppmi_shift: float = 5.0) -> None:
-    """Build game embeddings from a bipartite game–tag graph via SPPMI + SVD.
+def _rank_weight(r: int, Rmax: int, w_min: float, alpha: float) -> float:
+    x = 1.0 - (r - 1) / max(Rmax - 1, 1)
+    return w_min + (1.0 - w_min) * (x ** alpha)
 
-    - Edge weight uses a rank-based weight w = (21 - rank) / 20 (same as before)
-    - SPPMI(g, t) = max(log p(g,t) - log p(g) - log p(t) - log(k), 0), k = sppmi_shift
-    - TruncatedSVD to fixed dim, then row L2-normalization
+
+def run_tag_pca(
+    games_df: pd.DataFrame,
+    svd_dim: int = 128,
+    R_max: int = 20,
+    w_min: float = 0.8,
+    alpha: float = 1.2,
+    min_tag_count: int = 3,
+    min_tag_df: int = 10,
+    beta: float = 0.15,
+    beta_max: float = 0.35,
+    m_pair: int = 20,
+    alpha_cds: float = 0.75,
+    sppmi_shift: float = 10.0,
+) -> None:
+    """Build robust tag-based game embeddings.
+
+    IDF weighting, co-tag PMI boosts and CDS-smoothed SPPMI produce dense
+    embeddings whose artifacts are written to ``ml/data``.
     """
-    tag_id_map = load_json('ml/data/tag_id_map.json')
+
+    tag_id_map = load_json("ml/data/tag_id_map.json")
+    N_games = len(games_df)
+
+    # ------------------------------------------------------------------
+    # Document frequency over full corpus
+    # ------------------------------------------------------------------
     V = len(tag_id_map)
-    N = len(games_df)
-
-    app_ids = games_df['app_id'].astype(int).to_numpy()
-
-    # Build sparse game–tag weight matrix W (CSR)
-    rows = []
-    cols = []
-    data = []
-    for row_idx, row in games_df.iterrows():
-        tags = row.get('tags') or []
-        for tag_id, rank in tags:
+    df_counts = np.zeros(V, dtype=np.int64)
+    for _, row in games_df.iterrows():
+        tags = row.get("tags") or []
+        seen = set()
+        for tag_id, _ in tags[:R_max]:
             key = str(tag_id)
             j = tag_id_map.get(key)
+            if j is not None and j not in seen:
+                df_counts[int(j)] += 1
+                seen.add(j)
+    idf = np.log((N_games + 1) / (df_counts + 1)) + 1.0
+
+    keep_mask = df_counts >= int(min_tag_df)
+    kept_indices = np.where(keep_mask)[0]
+    idf_kept = idf[kept_indices].astype("float32")
+    index_map = {int(orig): int(new) for new, orig in enumerate(kept_indices)}
+    kept_tag_map = {
+        tid: index_map[int(j)]
+        for tid, j in tag_id_map.items()
+        if keep_mask[int(j)]
+    }
+    V_kept = len(kept_indices)
+
+    # ------------------------------------------------------------------
+    # Co-tag PMI table (binary counts)
+    # ------------------------------------------------------------------
+    tag_counts = np.zeros(V_kept, dtype=np.int64)
+    pair_counts: dict[tuple[int, int], int] = {}
+    for _, row in games_df.iterrows():
+        tags = row.get("tags") or []
+        idxs = sorted({kept_tag_map[str(tid)] for tid, _ in tags[:R_max] if str(tid) in kept_tag_map})
+        for j in idxs:
+            tag_counts[j] += 1
+        for a, b in combinations(idxs, 2):
+            if a > b:
+                a, b = b, a
+            pair_counts[(a, b)] = pair_counts.get((a, b), 0) + 1
+    p_j = tag_counts / max(N_games, 1)
+
+    rows_pmi, cols_pmi, data_pmi = [], [], []
+    pmi_dict: dict[int, dict[int, float]] = {}
+    for (a, b), c in pair_counts.items():
+        if c < m_pair:
+            continue
+        p_ab = c / N_games
+        denom = p_j[a] * p_j[b]
+        if denom <= 0:
+            continue
+        val = math.log(p_ab / denom)
+        if val <= 0:
+            continue
+        rows_pmi.append(a)
+        cols_pmi.append(b)
+        data_pmi.append(val)
+        pmi_dict.setdefault(a, {})[b] = val
+        pmi_dict.setdefault(b, {})[a] = val
+    pmi_matrix = sparse.coo_matrix((data_pmi, (rows_pmi, cols_pmi)), shape=(V_kept, V_kept))
+
+    # ------------------------------------------------------------------
+    # Build weighted game-tag matrix on training subset
+    # ------------------------------------------------------------------
+    games_train = games_df[games_df["tags"].apply(lambda t: len(t or []) >= min_tag_count)].reset_index(drop=True)
+    N_train = len(games_train)
+    rows, cols, data = [], [], []
+    app_ids = games_train["app_id"].astype(int).to_numpy()
+    for i, row in games_train.iterrows():
+        tags = row.get("tags") or []
+        for tag_id, rank in tags[:R_max]:
+            key = str(tag_id)
+            j = kept_tag_map.get(key)
             if j is None:
                 continue
-            w = (21 - int(rank)) / 20.0
-            if w <= 0:
-                continue
-            rows.append(row_idx)
-            cols.append(int(j))
-            data.append(float(w))
-
+            w = _rank_weight(int(rank), R_max, w_min, alpha)
+            rows.append(i)
+            cols.append(j)
+            data.append(float(w * idf_kept[j]))
     if not data:
-        raise RuntimeError('No tag edges found to build bipartite embeddings')
+        raise RuntimeError("No tag edges found to build embeddings")
+    W = sparse.csr_matrix((data, (rows, cols)), shape=(N_train, V_kept), dtype=np.float64)
 
-    W = sparse.csr_matrix((data, (rows, cols)), shape=(N, V), dtype=np.float64)
+    # Co-tag PMI boost per game
+    for i in range(N_train):
+        start, end = W.indptr[i], W.indptr[i + 1]
+        cols_i = W.indices[start:end]
+        data_i = W.data[start:end]
+        for pos, j in enumerate(cols_i):
+            neigh = [pmi_dict.get(j, {}).get(k, 0.0) for k in cols_i if k != j]
+            if neigh:
+                boost = sum(neigh) / len(neigh)
+                factor = 1.0 + beta * boost
+                factor = min(factor, 1.0 + beta_max)
+                data_i[pos] *= factor
+        row_sum = data_i.sum()
+        if row_sum > 0:
+            W.data[start:end] = data_i / row_sum
 
-    # Compute SPPMI matrix on edges
+    # ------------------------------------------------------------------
+    # SPPMI with Context Distribution Smoothing
+    # ------------------------------------------------------------------
     total_mass = float(W.sum())
-    p_g = np.asarray(W.sum(axis=1)).flatten() / max(total_mass, 1e-12)
+    p_i = np.asarray(W.sum(axis=1)).flatten() / max(total_mass, 1e-12)
     p_t = np.asarray(W.sum(axis=0)).flatten() / max(total_mass, 1e-12)
-    log_k = np.log(sppmi_shift)
+    log_k = math.log(sppmi_shift)
 
-    # For each nonzero entry, compute SPPMI value
-    W = W.tocoo()
+    W_coo = W.tocoo()
     sppmi_vals = []
-    for i, j, w in zip(W.row, W.col, W.data):
-        p_gt = w / total_mass
-        if p_gt <= 0 or p_g[i] <= 0 or p_t[j] <= 0:
+    for i, j, w in zip(W_coo.row, W_coo.col, W_coo.data):
+        p_ij = w / total_mass
+        if p_ij <= 0 or p_i[i] <= 0 or p_t[j] <= 0:
             sppmi_vals.append(0.0)
         else:
-            val = np.log(p_gt) - np.log(p_g[i]) - np.log(p_t[j]) - log_k
+            val = math.log(p_ij) - math.log(p_i[i]) - alpha_cds * math.log(p_t[j]) - log_k
             sppmi_vals.append(val if val > 0 else 0.0)
-    S = sparse.csr_matrix((sppmi_vals, (W.row, W.col)), shape=(N, V), dtype=np.float64)
+    S = sparse.csr_matrix((sppmi_vals, (W_coo.row, W_coo.col)), shape=(N_train, V_kept), dtype=np.float64)
 
-    # Truncated SVD to fixed dimensions
-    k = min(dim, min(N, V) - 1) if min(N, V) > 1 else 1
+    # ------------------------------------------------------------------
+    # Truncated SVD and normalization
+    # ------------------------------------------------------------------
+    k = min(svd_dim, max(min(N_train, V_kept) - 1, 1))
     svd = TruncatedSVD(n_components=k, random_state=42)
-    G_emb = svd.fit_transform(S)
-
-    # Row L2-normalize
-    norms = np.linalg.norm(G_emb, axis=1, keepdims=True)
+    G = svd.fit_transform(S)
+    norms = np.linalg.norm(G, axis=1, keepdims=True)
     norms[norms == 0] = 1e-6
-    G_norm = (G_emb / norms).astype('float32')
+    G_norm = (G / norms).astype("float32")
 
-    os.makedirs('ml/data', exist_ok=True)
-    save_numpy(G_norm, 'ml/data/T_pca_norm.npy')  # keep filename for downstream
-    save_torch(svd, 'ml/data/pca_tags.pkl')        # store SVD model for reproducibility
-    save_numpy(app_ids, 'ml/data/tag_pca_app_ids.npy')
+    # ------------------------------------------------------------------
+    # Persist artifacts
+    # ------------------------------------------------------------------
+    os.makedirs("ml/data", exist_ok=True)
+    save_numpy(G_norm, "ml/data/tag_game_emb.npy")
+    save_torch(svd, "ml/data/tag_svd.pkl")
+    save_numpy(app_ids, "ml/data/tag_app_ids.npy")
+    save_numpy(idf_kept, "ml/data/tag_idf.npy")
+    sparse.save_npz("ml/data/tag_pair_pmi_plus.npz", pmi_matrix.tocsr())
+    params = {
+        "svd_dim": int(svd_dim),
+        "R_max": int(R_max),
+        "w_min": float(w_min),
+        "alpha": float(alpha),
+        "min_tag_count": int(min_tag_count),
+        "min_tag_df": int(min_tag_df),
+        "beta": float(beta),
+        "beta_max": float(beta_max),
+        "m_pair": int(m_pair),
+        "alpha_cds": float(alpha_cds),
+        "sppmi_shift": float(sppmi_shift),
+    }
+    save_json(params, "ml/data/tag_params.json")
     global_tag_mean = G_norm.mean(axis=0)
-    save_numpy(global_tag_mean, 'ml/data/global_tag_mean.npy')
-    print(f'✅ Chunk 3 bipartite SPPMI+SVD saved (dim={k})')
-
+    save_numpy(global_tag_mean, "ml/data/tag_global_mean.npy")
+    print(f"✅ Chunk 3 tag embeddings saved (dim={k}, games={N_train}, tags={V_kept})")

--- a/ml/pipeline/chunk5_item_meta.py
+++ b/ml/pipeline/chunk5_item_meta.py
@@ -37,7 +37,7 @@ def run_item_meta_embedding() -> None:
         appid_to_rowidx = {int(k): int(v) for k, v in json.load(f).items()}
 
     # Load tag/text embeddings and their app_id arrays
-    T_pca_norm = load_numpy('ml/data/T_pca_norm.npy')
+    tag_game_emb_all = load_numpy('ml/data/tag_game_emb.npy')
     E_short = load_numpy('ml/data/E_qwen3_short.npy')
     E_long = load_numpy('ml/data/E_qwen3_long.npy')
     print(f"E_short loaded with shape {E_short.shape} and dtype {E_short.dtype}")
@@ -49,9 +49,9 @@ def run_item_meta_embedding() -> None:
         print(f"E_qwen3 zero-norm rows: {zero_norms}")
     e_norms[e_norms == 0] = 1
     E_qwen3 = E_qwen3 / e_norms[:, None]
-    tag_app_ids = load_numpy('ml/data/tag_pca_app_ids.npy')
+    app_ids_all = load_numpy('ml/data/tag_app_ids.npy')
 
-    tag_idx_map = {int(aid): idx for idx, aid in enumerate(tag_app_ids)}
+    tag_idx_map = {int(aid): idx for idx, aid in enumerate(app_ids_all)}
     # Build reverse mapping rowidx->appid to iterate in structured order
     num_rows = len(appid_to_rowidx)
     row_to_appid = [None] * num_rows
@@ -60,7 +60,7 @@ def run_item_meta_embedding() -> None:
             row_to_appid[ridx] = int(aid)
 
     structured_f = []
-    T_f = []
+    tag_emb_f = []
     E_f = []
     app_ids_f = []
     for ridx, aid in enumerate(row_to_appid):
@@ -70,19 +70,19 @@ def run_item_meta_embedding() -> None:
         if t_idx is None:
             continue
         structured_f.append(X_structured[ridx])
-        T_f.append(T_pca_norm[t_idx])
+        tag_emb_f.append(tag_game_emb_all[t_idx])
         E_f.append(E_qwen3[t_idx])
         app_ids_f.append(aid)
 
     structured = np.array(structured_f)
-    T_pca_norm = np.array(T_f)
+    tag_game_emb = np.array(tag_emb_f)
     E_qwen3 = np.array(E_f)
     app_ids = np.array(app_ids_f)
     print(f"X_structured dims: {structured.shape}")
-    print(f"T_pca_norm dims: {T_pca_norm.shape}")
+    print(f"tag_game_emb dims: {tag_game_emb.shape}")
     print(f"E_qwen3 dims: {E_qwen3.shape}")
     # X_structured is already scaled; concatenate directly with tag PCs and text embeddings
-    item_meta_raw = np.concatenate([structured, T_pca_norm, E_qwen3], axis=1)
+    item_meta_raw = np.concatenate([structured, tag_game_emb, E_qwen3], axis=1)
     print(f"item_meta_raw shape: {item_meta_raw.shape}")
     norms = np.linalg.norm(item_meta_raw, axis=1, keepdims=True)
     norms[norms == 0] = 1e-8
@@ -114,7 +114,7 @@ def run_item_meta_embedding() -> None:
     save_json(mapping, 'ml/data/app_id_to_meta_index.json')
     schema = {
         'structured': int(structured.shape[1]),
-        'tag': int(T_pca_norm.shape[1]),
+        'tag': int(tag_game_emb.shape[1]),
         'text': int(E_qwen3.shape[1]),
         'final': int(embs_np.shape[1]),
     }

--- a/ml/pipeline/chunk6_faiss.py
+++ b/ml/pipeline/chunk6_faiss.py
@@ -25,13 +25,13 @@ def build_faiss_indices() -> None:
     meta_app_ids = np.array(list(app_id_to_meta_index.keys()), dtype=int)
     meta_indices = np.array(list(app_id_to_meta_index.values()), dtype=int)
 
-    # Load tag PCA embeddings and align using intersection of app_ids
-    T_pca_all = load_numpy('ml/data/T_pca_norm.npy').astype(np.float32)
-    tag_app_ids = load_numpy('ml/data/tag_pca_app_ids.npy').astype(int)
+    # Load tag embeddings and align using intersection of app_ids
+    tag_emb_all = load_numpy('ml/data/tag_game_emb.npy').astype(np.float32)
+    tag_app_ids = load_numpy('ml/data/tag_app_ids.npy').astype(int)
     common_app_ids, tag_idx, meta_pos = np.intersect1d(
         tag_app_ids, meta_app_ids, return_indices=True
     )
-    T_final = T_pca_all[tag_idx]
+    T_final = tag_emb_all[tag_idx]
     kept_app_ids = common_app_ids.astype(int).tolist()
 
     # Build tags FAISS index

--- a/ml/pipeline/chunk7_user_profile.py
+++ b/ml/pipeline/chunk7_user_profile.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from .utils import load_numpy, build_id_to_index_map, get_current_utc_date
 
-_T_PCA_NORM = None
+_TAG_GAME_EMB = None
 _TAG_APP_ID_TO_INDEX = None
 _STRUCTURED_OK = None
 _GLOBAL_TAG_MEAN = None
@@ -30,19 +30,19 @@ def compute_user_meta_raw(
     if data_dir is None:
         data_dir = os.getenv("ML_DATA_DIR", "ml/data")
 
-    global _T_PCA_NORM, _TAG_APP_ID_TO_INDEX, _STRUCTURED_OK, _GLOBAL_TAG_MEAN
-    if _T_PCA_NORM is None:
-        _T_PCA_NORM = load_numpy(os.path.join(data_dir, 'T_pca_norm.npy'))
-        tag_app_ids = load_numpy(os.path.join(data_dir, 'tag_pca_app_ids.npy')).tolist()
+    global _TAG_GAME_EMB, _TAG_APP_ID_TO_INDEX, _STRUCTURED_OK, _GLOBAL_TAG_MEAN
+    if _TAG_GAME_EMB is None:
+        _TAG_GAME_EMB = load_numpy(os.path.join(data_dir, 'tag_game_emb.npy'))
+        tag_app_ids = load_numpy(os.path.join(data_dir, 'tag_app_ids.npy')).tolist()
         _TAG_APP_ID_TO_INDEX = build_id_to_index_map([int(a) for a in tag_app_ids])
         try:
             with open(os.path.join(data_dir, 'appid_to_rowidx.json'), 'r', encoding='utf-8') as f:
                 _STRUCTURED_OK = set(int(k) for k in json.load(f).keys())
         except Exception:
             _STRUCTURED_OK = None
-        _GLOBAL_TAG_MEAN = load_numpy(os.path.join(data_dir, 'global_tag_mean.npy'))
+        _GLOBAL_TAG_MEAN = load_numpy(os.path.join(data_dir, 'tag_global_mean.npy'))
 
-    T_pca_norm = _T_PCA_NORM
+    tag_game_emb = _TAG_GAME_EMB
     tag_app_id_to_index = _TAG_APP_ID_TO_INDEX
     structured_ok = _STRUCTURED_OK
     global_tag_mean = _GLOBAL_TAG_MEAN
@@ -58,8 +58,8 @@ def compute_user_meta_raw(
             if structured_ok is not None and a not in structured_ok:
                 continue
             idx = tag_app_id_to_index.get(a)
-            if idx is not None and idx < len(T_pca_norm):
-                vectors.append(T_pca_norm[int(idx)])
+            if idx is not None and idx < len(tag_game_emb):
+                vectors.append(tag_game_emb[int(idx)])
         if vectors:
             user_tag_profile = np.mean(
                 np.stack(vectors, axis=0), axis=0, dtype=np.float32

--- a/ml/pipeline/train_pipeline.py
+++ b/ml/pipeline/train_pipeline.py
@@ -174,15 +174,15 @@ def main():
                 "structured_app_ids.npy",  # from chunk2
                 "structured_min.npy",      # from chunk2
                 "structured_max.npy",      # from chunk2
-                "T_pca_norm.npy",          # from chunk3
+                "tag_game_emb.npy",       # from chunk3
                 "E_qwen3_short.npy",      # from chunk4
                 "E_qwen3_long.npy",       # from chunk4
-                "tag_pca_app_ids.npy",     # from chunk3
+                "tag_app_ids.npy",        # from chunk3
             ])
             print_structured_quantiles()
         elif name == "chunk6":
             req([
-                "T_pca_norm.npy",          # from chunk3
+                "tag_game_emb.npy",       # from chunk3
                 "item_meta_embs.npy",      # from chunk5
                 "structured_app_ids.npy",  # from chunk2
             ])
@@ -193,9 +193,9 @@ def main():
                 "app_id_to_meta_index.json", # from chunk5
                 "global_popular_games.json", # from chunk1
                 "item_meta_embs.npy",        # from chunk5
-                "T_pca_norm.npy",            # from chunk3
+                "tag_game_emb.npy",         # from chunk3
                 "structured_app_ids.npy",    # from chunk2
-                "global_tag_mean.npy",       # from chunk3
+                "tag_global_mean.npy",       # from chunk3
             ])
             print_structured_quantiles()
 


### PR DESCRIPTION
## Summary
- build tag-based game embeddings using IDF weighting, co-tag PMI boosts, and CDS-smoothed SPPMI before SVD
- rename outputs to include `tag` in filenames and update downstream modules
- clarify tag-related variable names in item metadata and user profile modules

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9692a070832fb7c098a9ae13d49f