### PR TITLE
feat: add tag embedding diagnostics and metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ ml/data
 
 # Training user ids
 gatherer/training_steamids.txt
+
+# ML metrics
+ml/metrics/

--- a/ml/pipeline/chunk3_tags_pca.py
+++ b/ml/pipeline/chunk3_tags_pca.py
@@ -2,10 +2,12 @@ import os
 import math
 import json
 from itertools import combinations
+from typing import Optional, Sequence
 
 import numpy as np
 import pandas as pd
 from sklearn.decomposition import TruncatedSVD
+from sklearn.metrics import average_precision_score
 from scipy import sparse
 
 from .utils import load_json, save_numpy, save_torch, save_json
@@ -18,7 +20,8 @@ def _rank_weight(r: int, Rmax: int, w_min: float, alpha: float) -> float:
 
 def run_tag_pca(
     games_df: pd.DataFrame,
-    svd_dim: int = 128,
+    svd_dim: int = 192,
+    svd_k_list: Optional[Sequence[int]] = None,
     R_max: int = 20,
     w_min: float = 0.8,
     alpha: float = 1.2,
@@ -32,10 +35,12 @@ def run_tag_pca(
 ) -> None:
     """Build robust tag-based game embeddings.
 
-    The function emits progress metrics – tag coverage, training matrix
-    density, and SVD explained variance – to help monitor embedding quality.
-    IDF weighting, co-tag PMI boosts and CDS-smoothed SPPMI produce dense
-    embeddings whose artifacts are written to ``ml/data``.
+    Optionally sweeps over several ``k`` values when performing Truncated SVD
+    to choose a suitable embedding dimensionality. The function emits
+    progress metrics – tag coverage, training matrix density, and SVD
+    explained variance – to help monitor embedding quality. IDF weighting,
+    co-tag PMI boosts and CDS-smoothed SPPMI produce dense embeddings whose
+    artifacts are written to ``ml/data``.
     """
 
     tag_id_map = load_json("ml/data/tag_id_map.json")
@@ -67,10 +72,13 @@ def run_tag_pca(
         if keep_mask[int(j)]
     }
     V_kept = len(kept_indices)
+    kept_tags_fraction = V_kept / max(V, 1)
     print(
         f"[chunk3] Keeping {V_kept}/{V} tags after min_df>={int(min_tag_df)} filter",
         flush=True,
     )
+    metrics: dict[str, object] = {}
+    metrics["matrix_health"] = {"kept_tags_fraction": float(kept_tags_fraction)}
 
     # ------------------------------------------------------------------
     # Co-tag PMI table (binary counts)
@@ -129,10 +137,15 @@ def run_tag_pca(
         raise RuntimeError("No tag edges found to build embeddings")
     W = sparse.csr_matrix((data, (rows, cols)), shape=(N_train, V_kept), dtype=np.float64)
     mean_tags = float(W.getnnz(axis=1).mean()) if N_train > 0 else 0.0
+    metrics["matrix_health"]["avg_tags_per_game"] = float(mean_tags)
     print(
         f"[chunk3] Training matrix built for {N_train} games (avg tags/game={mean_tags:.2f})",
         flush=True,
     )
+    game_tag_sets = [
+        {str(tid) for tid, _ in (row.get("tags") or [])[:R_max]}
+        for _, row in games_train.iterrows()
+    ]
 
     # Co-tag PMI boost per game
     for i in range(N_train):
@@ -169,26 +182,137 @@ def run_tag_pca(
             sppmi_vals.append(val if val > 0 else 0.0)
     S = sparse.csr_matrix((sppmi_vals, (W_coo.row, W_coo.col)), shape=(N_train, V_kept), dtype=np.float64)
     density = S.nnz / max(S.shape[0] * S.shape[1], 1)
+    metrics["matrix_health"]["sppmi_density"] = float(density)
     print(
         f"[chunk3] SPPMI matrix {S.shape} with {S.nnz} non-zeros (density={density:.6f})",
         flush=True,
     )
 
     # ------------------------------------------------------------------
-    # Truncated SVD and normalization
+    # Truncated SVD sweep and normalization
     # ------------------------------------------------------------------
-    k = min(svd_dim, max(min(N_train, V_kept) - 1, 1))
-    svd = TruncatedSVD(n_components=k, random_state=42)
-    G = svd.fit_transform(S)
+    k_candidates = sorted(set(svd_k_list or [svd_dim]))
+    sweep_results: dict[str, dict[str, float]] = {}
+    best_k = None
+    best_svd: Optional[TruncatedSVD] = None
+    best_G = None
+    for k in k_candidates:
+        k_eff = min(k, max(min(N_train, V_kept) - 1, 1))
+        svd_tmp = TruncatedSVD(n_components=k_eff, random_state=42)
+        G_tmp = svd_tmp.fit_transform(S)
+        evr = svd_tmp.explained_variance_ratio_
+        cum_evr = float(evr.sum())
+        comp1 = float(evr[0]) if evr.size else 0.0
+        sweep_results[str(k_eff)] = {
+            "cumulative_evr": cum_evr,
+            "comp1": comp1,
+        }
+        if best_k is None and cum_evr >= 0.80 and comp1 <= 0.10:
+            best_k = k_eff
+            best_svd = svd_tmp
+            best_G = G_tmp
+    if best_k is None:
+        best_k = k_eff
+        best_svd = svd_tmp
+        best_G = G_tmp
+
+    svd = best_svd
+    G = best_G
     norms = np.linalg.norm(G, axis=1, keepdims=True)
     norms[norms == 0] = 1e-6
     G_norm = (G / norms).astype("float32")
     exp_var = float(svd.explained_variance_ratio_.sum())
     top5 = np.round(svd.explained_variance_ratio_[:5], 4).tolist()
+    comp1 = float(svd.explained_variance_ratio_[0]) if svd.explained_variance_ratio_.size else 0.0
+    comp2 = float(svd.explained_variance_ratio_[1]) if svd.explained_variance_ratio_.size > 1 else 0.0
     print(
         f"[chunk3] SVD explained variance {exp_var:.2%} (first 5 comps: {top5})",
         flush=True,
     )
+    if comp1 > 0.10:
+        print(
+            f"[chunk3] ⚠️ First component explains {comp1:.2%} variance (>10%)",
+            flush=True,
+        )
+    if comp1 + comp2 > 0.18:
+        print(
+            f"[chunk3] ⚠️ First two components explain {(comp1 + comp2):.2%} variance (>18%)",
+            flush=True,
+        )
+    popularity_leak = exp_var >= 0.90 and comp1 > 0.12
+    if popularity_leak:
+        print(
+            f"[chunk3] ⚠️ Potential popularity leakage (EVR≥90%, comp1>{comp1:.2%})",
+            flush=True,
+        )
+    metrics["svd_dim_used"] = int(best_k)
+    metrics["explained_variance"] = float(exp_var)
+    metrics["top5_shares"] = [float(x) for x in top5]
+    metrics["sweep_results"] = sweep_results
+    metrics["spectral_warnings"] = []
+    if comp1 > 0.10:
+        metrics["spectral_warnings"].append("comp1_gt_10pct")
+    if comp1 + comp2 > 0.18:
+        metrics["spectral_warnings"].append("comp1_plus_comp2_gt_18pct")
+    metrics["popularity_leakage"] = bool(popularity_leak)
+
+    tag_vecs = svd.components_.T
+    tag_norms = np.linalg.norm(tag_vecs, axis=1, keepdims=True)
+    tag_norms[tag_norms == 0] = 1e-6
+    T_norm = (tag_vecs / tag_norms).astype("float32")
+
+    # ------------------------------------------------------------------
+    # Nearest-neighbor coherence
+    # ------------------------------------------------------------------
+    rng = np.random.default_rng(42)
+    sample_size = min(200, N_train)
+    if sample_size > 0:
+        sample_idx = rng.choice(N_train, size=sample_size, replace=False)
+        jaccards = []
+        for idx in sample_idx:
+            sims = G_norm[idx] @ G_norm.T
+            sims[idx] = -1.0
+            neigh_idx = np.argpartition(-sims, 10)[:10]
+            neigh_idx = neigh_idx[np.argsort(-sims[neigh_idx])]
+            A = game_tag_sets[idx]
+            for j in neigh_idx:
+                B = game_tag_sets[j]
+                inter = len(A & B)
+                union = len(A | B)
+                jaccards.append(inter / union if union > 0 else 0.0)
+        mean_j = float(np.mean(jaccards)) if jaccards else 0.0
+        p50_j = float(np.median(jaccards)) if jaccards else 0.0
+    else:
+        mean_j = 0.0
+        p50_j = 0.0
+    metrics["nn_coherence"] = {"mean_jaccard": mean_j, "p50_jaccard": p50_j}
+
+    # ------------------------------------------------------------------
+    # Held-out co-tag edge prediction
+    # ------------------------------------------------------------------
+    pairs = list(pair_counts.keys())
+    if pairs:
+        rng.shuffle(pairs)
+        n_test = max(1, int(0.1 * len(pairs)))
+        test_pairs = pairs[:n_test]
+        existing = set(pairs)
+        pos_sims = [float(T_norm[a] @ T_norm[b]) for a, b in test_pairs]
+        neg_sims = []
+        while len(neg_sims) < n_test:
+            a = int(rng.integers(V_kept))
+            b = int(rng.integers(V_kept))
+            if a == b:
+                continue
+            p = (a, b) if a < b else (b, a)
+            if p in existing:
+                continue
+            neg_sims.append(float(T_norm[p[0]] @ T_norm[p[1]]))
+        y_true = np.array([1] * n_test + [0] * n_test)
+        y_scores = np.array(pos_sims + neg_sims)
+        edge_ap = float(average_precision_score(y_true, y_scores))
+    else:
+        edge_ap = 0.0
+    metrics["edge_prediction_ap"] = edge_ap
 
     # ------------------------------------------------------------------
     # Persist artifacts
@@ -215,6 +339,8 @@ def run_tag_pca(
     save_json(params, "ml/data/tag_params.json")
     global_tag_mean = G_norm.mean(axis=0)
     save_numpy(global_tag_mean, "ml/data/tag_global_mean.npy")
+    os.makedirs("ml/metrics", exist_ok=True)
+    save_json(metrics, "ml/metrics/tag_metrics.json")
     print(
         f"✅ Chunk 3 tag embeddings saved (dim={k}, games={N_train}, tags={V_kept}, variance={exp_var:.2%})"
     )

--- a/ml/pipeline/train_pipeline.py
+++ b/ml/pipeline/train_pipeline.py
@@ -40,6 +40,12 @@ def main():
         default=None,
         help="override NUM_EPOCHS env for chunk10 training",
     )
+    parser.add_argument(
+        "--svd_dim",
+        type=int,
+        default=None,
+        help="override tag embedding dimension for chunk3",
+    )
     args = parser.parse_args()
 
     start_time = time.time()
@@ -72,7 +78,12 @@ def main():
                 load_games_df(), get_current_utc_date()
             ),
         ),
-        ("chunk3", lambda: chunk3_tags_pca.run_tag_pca(load_games_df())),
+        (
+            "chunk3",
+            lambda: chunk3_tags_pca.run_tag_pca(
+                load_games_df(), svd_dim=args.svd_dim or 192
+            ),
+        ),
         ("chunk4", lambda: chunk4_text_embeddings.run_text_embeddings(load_games_df())),
         ("chunk5", chunk5_item_meta.run_item_meta_embedding),
         ("chunk6", chunk6_faiss.build_faiss_indices),


### PR DESCRIPTION
## Summary
- sweep over candidate SVD dims for tag embeddings and choose dimension based on spectrum checks
- record matrix health, spectrum, NN coherence and edge prediction metrics and save to `ml/metrics`
- expose `--svd_dim` override in training pipeline and ignore generated metrics
- remove placeholder `ml/metrics/.gitkeep` and adjust `.gitignore`

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb4c47e44832f91d43f4d31975448