### PR TITLE
Add residual item meta encoder and bilinear scorer

### DIFF
--- a/ml/pipeline/__init__.py
+++ b/ml/pipeline/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "chunk10_train",
     "chunk11_inference",
     "train_pipeline",
+    "build_item_meta",
 ]
 
 
@@ -43,4 +44,17 @@ def __getattr__(name: str):
         globals()[name] = module
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def build_item_meta(mode: str):
+    """Factory for :class:`ItemMetaFC` using the stored schema."""
+    import os
+    import json
+
+    data_dir = os.getenv("ML_DATA_DIR", "ml/data")
+    schema_path = os.path.join(data_dir, "item_meta_schema.json")
+    with open(schema_path, "r", encoding="utf-8") as f:
+        schema = json.load(f)
+    input_dim = schema["structured"] + schema["tag"] + schema["text"]
+    return chunk5_item_meta.ItemMetaFC(input_dim, mode=mode)
 

--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -11,7 +11,7 @@ from torch.nn.utils import clip_grad_norm_
 from transformers import get_cosine_schedule_with_warmup
 
 from .chunk8_embeddings import EmbeddingTables
-from .chunk9_model import UserMetaFC, ScoreMLP
+from .chunk9_model import UserMetaFC, ScoreMLP, ScoreBilinear
 from .chunk7_user_profile import compute_user_meta_raw
 from .utils import (
     load_numpy,
@@ -57,6 +57,7 @@ def train_model(
     num_epochs: int | None = None,
     batch_size: int = 256,
     data_dir: str | None = None,
+    scorer: str = "mlp",
 ) -> None:
     """Train embedding models with pairwise ranking.
 
@@ -82,10 +83,13 @@ def train_model(
     tables.user_emb = tables.user_emb.to(device)
     tables.item_emb = tables.item_emb.to(device)
     user_meta_fc = UserMetaFC(tag_dim + 1).to(device)
-    score_mlp = ScoreMLP().to(device)
+    if scorer == "bilinear":
+        score_model = ScoreBilinear().to(device)
+    else:
+        score_model = ScoreMLP().to(device)
 
     params = list(tables.user_emb.parameters()) + list(tables.item_emb.parameters())
-    params += list(user_meta_fc.parameters()) + list(score_mlp.parameters())
+    params += list(user_meta_fc.parameters()) + list(score_model.parameters())
     optimizer = AdamW(params, lr=1e-4, weight_decay=1e-5)
     steps_per_epoch = ceil(len(user_ids) / batch_size)
 
@@ -170,7 +174,7 @@ def train_model(
                     )
                     item_meta = item_meta_embs[idx].unsqueeze(0)
                     x = torch.cat([u_emb, user_meta_emb, item_emb, item_meta], dim=1)
-                    scores.append(score_mlp(x).item())
+                    scores.append(score_model(x).item())
                     label = int(
                         (row["playtime_forever"] > 0)
                         or (row["playtime_2weeks"] > 0)
@@ -208,7 +212,7 @@ def train_model(
                     u_rep = u_emb.repeat(len(candidates), 1)
                     um_rep = user_meta_emb.repeat(len(candidates), 1)
                     x = torch.cat([u_rep, um_rep, item_embs, item_meta], dim=1)
-                    cand_scores = score_mlp(x).view(-1).cpu().numpy()
+                    cand_scores = score_model(x).view(-1).cpu().numpy()
                     cand_labels = np.zeros(len(candidates), dtype=int)
                     cand_labels[0] = 1
                     ranking = np.argsort(-cand_scores)
@@ -276,8 +280,8 @@ def train_model(
 
                 x_pos = torch.cat([u_emb, user_meta_emb, pos_emb, pos_meta], dim=1)
                 x_neg = torch.cat([u_emb, user_meta_emb, neg_emb, neg_meta], dim=1)
-                s_pos = score_mlp(x_pos)
-                s_neg = score_mlp(x_neg)
+                s_pos = score_model(x_pos)
+                s_neg = score_model(x_neg)
                 diff = torch.clamp(s_pos - s_neg, -30.0, 30.0)
                 loss = -torch.log(torch.sigmoid(diff))
                 losses.append(loss)
@@ -325,4 +329,22 @@ def train_model(
     tables.compute_means()
     tables.save(os.path.join(data_dir, "emb_tables"))
     save_checkpoint(user_meta_fc.state_dict(), os.path.join(data_dir, "user_meta_fc.pth"))
-    save_checkpoint(score_mlp.state_dict(), os.path.join(data_dir, "score_mlp.pth"))
+    fname = "score_bilinear.pth" if scorer == "bilinear" else "score_mlp.pth"
+    save_checkpoint(score_model.state_dict(), os.path.join(data_dir, fname))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train ranking model")
+    parser.add_argument("--scorer", choices=["mlp", "bilinear"], default="mlp")
+    parser.add_argument("--epochs", type=int, default=None)
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--data_dir", type=str, default=None)
+    args = parser.parse_args()
+    train_model(
+        num_epochs=args.epochs,
+        batch_size=args.batch_size,
+        data_dir=args.data_dir,
+        scorer=args.scorer,
+    )

--- a/ml/pipeline/chunk5_item_meta.py
+++ b/ml/pipeline/chunk5_item_meta.py
@@ -9,10 +9,14 @@ import json
 
 
 class ItemMetaFC(nn.Module):
-    def __init__(self, input_dim: int):
+    def __init__(self, input_dim: int, mode: str = "baseline"):
         super().__init__()
+        self.mode = mode
         self.fc1 = nn.Linear(input_dim, 512)
         self.bn1 = nn.BatchNorm1d(512)
+        if mode == "residual":
+            self.fc_res = nn.Linear(512, 512)
+            self.ln_res = nn.LayerNorm(512)
         self.fc2 = nn.Linear(512, 256)
         self.bn2 = nn.BatchNorm1d(256)
         self.fc3 = nn.Linear(256, 128)
@@ -22,6 +26,11 @@ class ItemMetaFC(nn.Module):
         x = self.bn1(x)
         x = F.relu(x)
         x = F.dropout(x, p=0.3, training=self.training)
+        if self.mode == "residual":
+            res = x
+            x = self.fc_res(x)
+            x = self.ln_res(x + res)
+            x = F.relu(x)
         x = self.fc2(x)
         x = self.bn2(x)
         x = F.relu(x)
@@ -30,7 +39,7 @@ class ItemMetaFC(nn.Module):
         return x
 
 
-def run_item_meta_embedding() -> None:
+def run_item_meta_embedding(mode: str = "baseline") -> None:
     # Load stationary structured features (already scaled) and row index mapping
     X_structured = load_numpy('ml/data/X_structured.npy')
     with open('ml/data/appid_to_rowidx.json', 'r', encoding='utf-8') as f:
@@ -92,7 +101,7 @@ def run_item_meta_embedding() -> None:
     )
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    model = ItemMetaFC(item_meta_raw.shape[1]).to(device)
+    model = ItemMetaFC(item_meta_raw.shape[1], mode=mode).to(device)
     model.eval()
     batch_size = 20000
     total_batches = (len(item_meta_raw) + batch_size - 1) // batch_size

--- a/ml/pipeline/chunk9_model.py
+++ b/ml/pipeline/chunk9_model.py
@@ -42,3 +42,14 @@ class ScoreMLP(nn.Module):
         x = self.fc3(x)
         return x
 
+
+class ScoreBilinear(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bilinear = nn.Bilinear(256, 256, 1)
+
+    def forward(self, x):
+        user = x[:, :256]
+        item = x[:, 256:]
+        return self.bilinear(user, item)
+


### PR DESCRIPTION
## Summary
- extend ItemMetaFC with optional residual block and mode flag
- add build_item_meta factory to init to load schema and build model
- provide bilinear scoring option and CLI flag to select scorer during training

## Testing
- `python -m py_compile ml/pipeline/*.py`
- `python - <<'PY'
from ml.pipeline.chunk5_item_meta import run_item_meta_embedding
run_item_meta_embedding(mode='baseline')
PY` *(fails: FileNotFoundError: ml/data/X_structured.npy)*
- `python -m ml.pipeline.chunk10_train --scorer mlp --epochs 1` *(fails: FileNotFoundError: ml/data/interactions_df.pkl)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc5846fd8832f85a7492d66bcf3c4