### PR TITLE
Add user/item bias embeddings and residual ScoreMLP

### DIFF
--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -78,7 +78,7 @@ def train_model(
     tables.user_emb = tables.user_emb.to(device)
     tables.item_emb = tables.item_emb.to(device)
     user_meta_fc = UserMetaFC(tag_dim + 1).to(device)
-    score_mlp = ScoreMLP().to(device)
+    score_mlp = ScoreMLP(len(user_ids), len(app_id_to_index)).to(device)
 
     params = list(tables.user_emb.parameters()) + list(tables.item_emb.parameters())
     params += list(user_meta_fc.parameters()) + list(score_mlp.parameters())
@@ -157,6 +157,7 @@ def train_model(
                 user_meta_emb = user_meta_fc(user_meta)
                 scores: List[float] = []
                 labels: List[int] = []
+                u_idx_tensor = torch.tensor([u_idx], dtype=torch.long, device=device)
                 for _, row in val_df.iterrows():
                     app = int(row["app_id"])
                     idx = app_id_to_index.get(str(app), 0)
@@ -165,7 +166,8 @@ def train_model(
                     )
                     item_meta = item_meta_embs[idx].unsqueeze(0)
                     x = torch.cat([u_emb, user_meta_emb, item_emb, item_meta], dim=1)
-                    scores.append(score_mlp(x).item())
+                    item_idx_tensor = torch.tensor([idx], dtype=torch.long, device=device)
+                    scores.append(score_mlp(x, u_idx_tensor, item_idx_tensor).item())
                     label = int(
                         (row["playtime_forever"] > 0)
                         or (row["playtime_2weeks"] > 0)
@@ -203,7 +205,8 @@ def train_model(
                     u_rep = u_emb.repeat(len(candidates), 1)
                     um_rep = user_meta_emb.repeat(len(candidates), 1)
                     x = torch.cat([u_rep, um_rep, item_embs, item_meta], dim=1)
-                    cand_scores = score_mlp(x).view(-1).cpu().numpy()
+                    u_batch = torch.full((len(candidates),), u_idx, dtype=torch.long, device=device)
+                    cand_scores = score_mlp(x, u_batch, idx_tensor).view(-1).cpu().numpy()
                     cand_labels = np.zeros(len(candidates), dtype=int)
                     cand_labels[0] = 1
                     ranking = np.argsort(-cand_scores)
@@ -289,8 +292,9 @@ def train_model(
 
                 x_pos = torch.cat([u_rep, um_rep, pos_emb, pos_meta], dim=1)
                 x_neg = torch.cat([u_rep, um_rep, neg_emb, neg_meta], dim=1)
-                s_pos = score_mlp(x_pos)
-                s_neg = score_mlp(x_neg)
+                u_batch = torch.full((len(pos_list),), u_idx, dtype=torch.long, device=device)
+                s_pos = score_mlp(x_pos, u_batch, pos_idx)
+                s_neg = score_mlp(x_neg, u_batch, neg_idx)
 
                 diff = torch.clamp(s_pos - s_neg, -30.0, 30.0)
                 loss = -torch.log(torch.sigmoid(diff)).mean()

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -22,12 +22,14 @@ def _load_structured_schema(data_dir: str):
         return None
 
 
-def _filter_unique(candidates, K, exclude_ids):
+def _filter_unique(candidates, K, exclude_ids, allowed_ids=None):
     seen = set(int(x) for x in exclude_ids)
     results = []
     for c in candidates:
         app_id = int(c['app_id']) if isinstance(c, dict) else int(c)
         if app_id in seen:
+            continue
+        if allowed_ids is not None and app_id not in allowed_ids:
             continue
         seen.add(app_id)
         results.append(c)
@@ -55,17 +57,25 @@ def recommend(
         data_dir = os.getenv('ML_DATA_DIR', 'ml/data')
     tag_dim = load_numpy(os.path.join(data_dir, 'tag_game_emb.npy')).shape[1]
     user_meta_fc = UserMetaFC(tag_dim + 1).to(device)
-    score_mlp = ScoreMLP().to(device)
-    user_meta_fc.load_state_dict(load_torch(os.path.join(data_dir, 'user_meta_fc.pth'), device))
-    score_mlp.load_state_dict(load_torch(os.path.join(data_dir, 'score_mlp.pth'), device))
     tables = EmbeddingTables(0, 0)
     tables.load(os.path.join(data_dir, 'emb_tables'), device=device)
+    score_mlp = ScoreMLP(
+        tables.user_emb.num_embeddings, tables.item_emb.num_embeddings
+    ).to(device)
+    user_meta_fc.load_state_dict(load_torch(os.path.join(data_dir, 'user_meta_fc.pth'), device))
+    score_mlp.load_state_dict(load_torch(os.path.join(data_dir, 'score_mlp.pth'), device))
     map_path = os.path.join(data_dir, 'user_id_to_index.json')
     user_id_map = load_json(map_path) if os.path.exists(map_path) else {}
     item_meta_embs = load_numpy(os.path.join(data_dir, 'item_meta_embs.npy'))
     index_meta = faiss.read_index(os.path.join(data_dir, 'faiss_meta.index'))
     index_to_app = load_json(os.path.join(data_dir, 'index_to_app_id_meta.json'))
     app_id_to_index = load_json(os.path.join(data_dir, 'app_id_to_meta_index.json'))
+
+    allowed_items = {
+        int(app): idx
+        for app, idx in app_id_to_index.items()
+        if idx < tables.item_emb.num_embeddings and idx < len(item_meta_embs)
+    }
 
     user_df = interactions_df[interactions_df['user_id'] == user_id]
     if user_df.empty and user_library_df is not None:
@@ -95,10 +105,10 @@ def recommend(
             user_df = lib
         else:
             popular = load_json(os.path.join(data_dir, 'global_popular_games.json'))
-            return _filter_unique(popular, K, lib['app_id'].astype(int).tolist())
+            return _filter_unique(popular, K, lib['app_id'].astype(int).tolist(), allowed_items)
     elif user_df.empty:
         popular = load_json(os.path.join(data_dir, 'global_popular_games.json'))
-        return _filter_unique(popular, K, [])
+        return _filter_unique(popular, K, [], allowed_items)
 
     pos_mask_df = (
         (user_df['playtime_forever'] > 0)
@@ -107,7 +117,7 @@ def recommend(
     )
     if pos_mask_df.sum() < 20:
         popular = load_json(os.path.join(data_dir, 'global_popular_games.json'))
-        return _filter_unique(popular, K, user_df['app_id'].astype(int).tolist())
+        return _filter_unique(popular, K, user_df['app_id'].astype(int).tolist(), allowed_items)
 
     owned_ids = user_df['app_id'].astype(int).tolist()
     exclude_ids: set[int] = set(owned_ids)
@@ -130,21 +140,23 @@ def recommend(
         new_batch = []
         for idx in cand_idxs[0][start:search_k]:
             app_id = index_to_app[idx] if isinstance(index_to_app, list) else index_to_app[str(idx)]
-            if app_id in seen_cands:
+            if app_id in seen_cands or int(app_id) not in allowed_items:
                 continue
             seen_cands.add(app_id)
-            candidate_ids.append(app_id)
-            new_batch.append(app_id)
+            candidate_ids.append(int(app_id))
+            new_batch.append(int(app_id))
             if len(candidate_ids) >= K:
                 break
         print(f"searched {search_k}, new apps {new_batch}")
 
 
     scores = []
+    scored_ids: list[int] = []
     with torch.no_grad():
         idx_u = user_id_map.get(str(user_id))
         if idx_u is not None and idx_u < tables.user_emb.num_embeddings:
             u_emb = tables.user_emb(torch.tensor([idx_u], device=device))
+            u_idx_tensor = torch.tensor([idx_u], dtype=torch.long, device=device)
         else:
             pos_apps = user_df[
                 (user_df['playtime_forever'] > 0)
@@ -162,30 +174,29 @@ def recommend(
                 u_emb = emb.mean(dim=0, keepdim=True)
             else:
                 u_emb = tables.mean_user_emb.unsqueeze(0).to(device)
+            u_idx_tensor = None
         for app_id in candidate_ids:
-            idx = app_id_to_index.get(str(app_id), None)
-            if idx is not None and idx < tables.item_emb.num_embeddings:
-                i_emb = tables.item_emb(torch.tensor([idx], device=device))
-            else:
-                i_emb = tables.mean_item_emb.unsqueeze(0).to(device)
-            if idx is not None and idx < len(item_meta_embs):
-                i_meta = torch.from_numpy(item_meta_embs[idx]).float().unsqueeze(0).to(device)
-            else:
-                i_meta = torch.zeros((1, item_meta_embs.shape[1]), device=device)
+            idx = allowed_items.get(app_id)
+            if idx is None:
+                continue
+            i_emb = tables.item_emb(torch.tensor([idx], device=device))
+            item_idx_tensor = torch.tensor([idx], dtype=torch.long, device=device)
+            i_meta = torch.from_numpy(item_meta_embs[idx]).float().unsqueeze(0).to(device)
             feat = torch.cat([u_emb, user_meta_emb, i_emb, i_meta], dim=1)
-            s = score_mlp(feat)
+            s = score_mlp(feat, u_idx_tensor, item_idx_tensor)
             scores.append(s.item())
+            scored_ids.append(app_id)
 
-    ranked = [x for _, x in sorted(zip(scores, candidate_ids), key=lambda t: t[0], reverse=True)]
+    ranked = [x for _, x in sorted(zip(scores, scored_ids), key=lambda t: t[0], reverse=True)]
 
     # Remove duplicates and items the user already owns.
-    recs = _filter_unique(ranked, K, exclude_ids)
+    recs = _filter_unique(ranked, K, exclude_ids, allowed_items)
 
     # If FAISS produced too many duplicates, backfill with popular titles to
     # still return K unique recommendations.
     if len(recs) < K:
         popular = load_json(os.path.join(data_dir, 'global_popular_games.json'))
         exclude = owned_ids + [int(r['app_id']) if isinstance(r, dict) else int(r) for r in recs]
-        recs.extend(_filter_unique(popular, K - len(recs), exclude))
+        recs.extend(_filter_unique(popular, K - len(recs), exclude, allowed_items))
 
     return recs

--- a/ml/pipeline/chunk9_model.py
+++ b/ml/pipeline/chunk9_model.py
@@ -22,23 +22,41 @@ class UserMetaFC(nn.Module):
 
 
 class ScoreMLP(nn.Module):
-    def __init__(self):
+    def __init__(self, num_users: int, num_items: int):
         super().__init__()
+        self.user_bias = nn.Embedding(num_users, 1)
+        self.item_bias = nn.Embedding(num_items, 1)
+
         self.fc1 = nn.Linear(512, 512)
         self.bn1 = nn.LayerNorm(512)
-        self.fc2 = nn.Linear(512, 256)
-        self.bn2 = nn.LayerNorm(256)
-        self.fc3 = nn.Linear(256, 1)
+        self.fc2 = nn.Linear(512, 512)
+        self.bn2 = nn.LayerNorm(512)
+        self.fc3 = nn.Linear(512, 256)
+        self.bn3 = nn.LayerNorm(256)
+        self.fc4 = nn.Linear(256, 1)
 
-    def forward(self, x):
-        x = self.fc1(x)
-        x = self.bn1(x)
-        x = F.relu(x)
-        x = F.dropout(x, p=0.3, training=self.training)
-        x = self.fc2(x)
-        x = self.bn2(x)
-        x = F.relu(x)
-        x = F.dropout(x, p=0.3, training=self.training)
-        x = self.fc3(x)
-        return x
+    def forward(self, x, user_idx: torch.LongTensor | None = None, item_idx: torch.LongTensor | None = None):
+        h = self.fc1(x)
+        h = self.bn1(h)
+        h = F.relu(h)
+        h = F.dropout(h, p=0.3, training=self.training)
+
+        res = h
+        h = self.fc2(h)
+        h = self.bn2(h)
+        h = F.relu(h)
+        h = F.dropout(h, p=0.3, training=self.training)
+        h = h + res
+
+        h = self.fc3(h)
+        h = self.bn3(h)
+        h = F.relu(h)
+        h = F.dropout(h, p=0.3, training=self.training)
+        out = self.fc4(h)
+
+        if user_idx is not None:
+            out = out + self.user_bias(user_idx)
+        if item_idx is not None:
+            out = out + self.item_bias(item_idx)
+        return out
 


### PR DESCRIPTION
## Summary
- add learnable user and item bias embeddings in `ScoreMLP`
- expand `ScoreMLP` with a residual MLP block for deeper scoring
- adjust training and inference pipelines to pass user/item indices for bias terms
- ensure inference skips items lacking embeddings or metadata so unknown games aren't recommended

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6e9a5c668832f8fcf916f8b734d86