### PR TITLE
Handle padding index for item and user embeddings

### DIFF
--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -70,14 +70,24 @@ def train_model(
     all_items = [int(a) for a in app_id_to_index.keys()]
     global_popular = load_json(os.path.join(data_dir, "global_popular_games.json"))
 
+    def _app_idx(app_id: int) -> int:
+        idx = app_id_to_index.get(str(app_id))
+        return idx + 1 if idx is not None else 0
+
+    def _user_idx(uid: int) -> int:
+        idx = user_id_map.get(uid)
+        return idx + 1 if idx is not None else 0
+
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    tag_dim = load_numpy(os.path.join(data_dir, "tag_game_emb.npy")).shape[1]
+    first_uid = user_ids[0]
+    _, _, first_meta = compute_user_meta_raw(first_uid, interactions, data_dir)
+    user_meta_dim = first_meta.shape[0]
 
     tables = EmbeddingTables(len(user_ids), len(app_id_to_index))
     tables.user_emb = tables.user_emb.to(device)
     tables.item_emb = tables.item_emb.to(device)
-    user_meta_fc = UserMetaFC(tag_dim + 1).to(device)
+    user_meta_fc = UserMetaFC(user_meta_dim).to(device)
     score_mlp = ScoreMLP().to(device)
 
     params = list(tables.user_emb.parameters()) + list(tables.item_emb.parameters())
@@ -85,12 +95,17 @@ def train_model(
     optimizer = AdamW(params, lr=1e-4, weight_decay=1e-5)
     steps_per_epoch = ceil(len(user_ids) / batch_size)
 
-    item_meta_embs = torch.from_numpy(
-        load_numpy(os.path.join(data_dir, "item_meta_embs.npy"))
-    ).float().to(device)
+    item_meta_np = load_numpy(os.path.join(data_dir, "item_meta_embs.npy")).astype(
+        np.float32
+    )
+    item_meta_np = np.vstack([
+        np.zeros((1, item_meta_np.shape[1]), dtype=item_meta_np.dtype),
+        item_meta_np,
+    ])
+    item_meta_embs = torch.from_numpy(item_meta_np).float().to(device)
 
-    user_meta_list: List[np.ndarray] = []
-    for uid in user_ids:
+    user_meta_list: List[np.ndarray] = [np.zeros(user_meta_dim, dtype=np.float32), first_meta]
+    for uid in user_ids[1:]:
         _, _, meta_raw = compute_user_meta_raw(uid, interactions, data_dir)
         user_meta_list.append(meta_raw)
     user_meta_tensor = torch.tensor(
@@ -143,7 +158,7 @@ def train_model(
             )
             if pos_mask.sum() == 0 or pos_mask.sum() == len(val_df):
                 continue
-            u_idx = user_id_map[uid]
+            u_idx = _user_idx(uid)
             user_pos_all = set(
                 splits[uid]["train"]["app_id"].tolist()
                 + splits[uid]["val"]["app_id"].tolist()
@@ -159,7 +174,7 @@ def train_model(
                 labels: List[int] = []
                 for _, row in val_df.iterrows():
                     app = int(row["app_id"])
-                    idx = app_id_to_index.get(str(app), 0)
+                    idx = _app_idx(app)
                     item_emb = tables.item_emb(
                         torch.tensor([idx], dtype=torch.long, device=device)
                     )
@@ -196,7 +211,7 @@ def train_model(
                         continue
                     negatives = np.random.choice(neg_pool, 99, replace=False)
                     candidates = [pos_app] + list(negatives)
-                    idxs = [app_id_to_index.get(str(c), 0) for c in candidates]
+                    idxs = [_app_idx(c) for c in candidates]
                     idx_tensor = torch.tensor(idxs, dtype=torch.long, device=device)
                     item_embs = tables.item_emb(idx_tensor)
                     item_meta = item_meta_embs[idx_tensor]
@@ -260,7 +275,7 @@ def train_model(
             optimizer.zero_grad()
             losses = []
             for u, pos_list, neg_list in batch_pairs:
-                u_idx = user_id_map[u]
+                u_idx = _user_idx(u)
                 u_emb = tables.user_emb(
                     torch.tensor([u_idx], dtype=torch.long, device=device)
                 )
@@ -268,12 +283,12 @@ def train_model(
                 user_meta_emb = user_meta_fc(user_meta)
 
                 pos_idx = torch.tensor(
-                    [app_id_to_index.get(str(p), 0) for p in pos_list],
+                    [_app_idx(p) for p in pos_list],
                     dtype=torch.long,
                     device=device,
                 )
                 neg_idx = torch.tensor(
-                    [app_id_to_index.get(str(n), 0) for n in neg_list],
+                    [_app_idx(n) for n in neg_list],
                     dtype=torch.long,
                     device=device,
                 )

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -53,19 +53,33 @@ def recommend(
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     if data_dir is None:
         data_dir = os.getenv('ML_DATA_DIR', 'ml/data')
-    tag_dim = load_numpy(os.path.join(data_dir, 'tag_game_emb.npy')).shape[1]
-    user_meta_fc = UserMetaFC(tag_dim + 1).to(device)
+    umeta_state = load_torch(os.path.join(data_dir, 'user_meta_fc.pth'), device)
+    user_meta_dim = umeta_state['fc1.weight'].shape[1]
+    user_meta_fc = UserMetaFC(user_meta_dim).to(device)
+    user_meta_fc.load_state_dict(umeta_state)
     score_mlp = ScoreMLP().to(device)
-    user_meta_fc.load_state_dict(load_torch(os.path.join(data_dir, 'user_meta_fc.pth'), device))
     score_mlp.load_state_dict(load_torch(os.path.join(data_dir, 'score_mlp.pth'), device))
     tables = EmbeddingTables(0, 0)
     tables.load(os.path.join(data_dir, 'emb_tables'), device=device)
     map_path = os.path.join(data_dir, 'user_id_to_index.json')
     user_id_map = load_json(map_path) if os.path.exists(map_path) else {}
-    item_meta_embs = load_numpy(os.path.join(data_dir, 'item_meta_embs.npy'))
+    item_meta_np = load_numpy(os.path.join(data_dir, 'item_meta_embs.npy')).astype(np.float32)
+    item_meta_np = np.vstack([
+        np.zeros((1, item_meta_np.shape[1]), dtype=item_meta_np.dtype),
+        item_meta_np,
+    ])
+    item_meta_embs = item_meta_np
     index_meta = faiss.read_index(os.path.join(data_dir, 'faiss_meta.index'))
     index_to_app = load_json(os.path.join(data_dir, 'index_to_app_id_meta.json'))
     app_id_to_index = load_json(os.path.join(data_dir, 'app_id_to_meta_index.json'))
+
+    def _app_idx(app_id: int) -> int:
+        idx = app_id_to_index.get(str(app_id))
+        return idx + 1 if idx is not None else 0
+
+    def _user_idx(uid: int) -> int:
+        idx = user_id_map.get(str(uid))
+        return idx + 1 if idx is not None else 0
 
     user_df = interactions_df[interactions_df['user_id'] == user_id]
     if user_df.empty and user_library_df is not None:
@@ -142,34 +156,38 @@ def recommend(
 
     scores = []
     with torch.no_grad():
-        idx_u = user_id_map.get(str(user_id))
-        if idx_u is not None and idx_u < tables.user_emb.num_embeddings:
-            u_emb = tables.user_emb(torch.tensor([idx_u], device=device))
+        idx_u = _user_idx(user_id)
+        if idx_u != 0 and idx_u < tables.user_emb.num_embeddings:
+            u_emb = tables.user_emb(torch.tensor([idx_u], dtype=torch.long, device=device))
         else:
             pos_apps = user_df[
                 (user_df['playtime_forever'] > 0)
                 | (user_df['playtime_2weeks'] > 0)
                 | (user_df['wishlisted'])
             ]['app_id'].unique()
-            item_indices = [
-                app_id_to_index.get(str(a))
-                for a in pos_apps
-                if app_id_to_index.get(str(a)) is not None
-                and app_id_to_index.get(str(a)) < tables.item_emb.num_embeddings
-            ]
+            item_indices = []
+            for a in pos_apps:
+                idx = _app_idx(a)
+                if idx != 0 and idx < tables.item_emb.num_embeddings:
+                    item_indices.append(idx)
             if item_indices:
                 emb = tables.item_emb(torch.tensor(item_indices, device=device))
                 u_emb = emb.mean(dim=0, keepdim=True)
             else:
                 u_emb = tables.mean_user_emb.unsqueeze(0).to(device)
         for app_id in candidate_ids:
-            idx = app_id_to_index.get(str(app_id), None)
-            if idx is not None and idx < tables.item_emb.num_embeddings:
+            idx = _app_idx(app_id)
+            if idx != 0 and idx < tables.item_emb.num_embeddings:
                 i_emb = tables.item_emb(torch.tensor([idx], device=device))
             else:
                 i_emb = tables.mean_item_emb.unsqueeze(0).to(device)
-            if idx is not None and idx < len(item_meta_embs):
-                i_meta = torch.from_numpy(item_meta_embs[idx]).float().unsqueeze(0).to(device)
+            if idx != 0 and idx < len(item_meta_embs):
+                i_meta = (
+                    torch.from_numpy(item_meta_embs[idx])
+                    .float()
+                    .unsqueeze(0)
+                    .to(device)
+                )
             else:
                 i_meta = torch.zeros((1, item_meta_embs.shape[1]), device=device)
             feat = torch.cat([u_emb, user_meta_emb, i_emb, i_meta], dim=1)

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -81,6 +81,12 @@ def recommend(
         idx = user_id_map.get(str(uid))
         return idx + 1 if idx is not None else 0
 
+    allowed_items = {
+        int(app): idx + 1
+        for app, idx in app_id_to_index.items()
+        if (idx + 1) < tables.item_emb.num_embeddings and (idx + 1) < len(item_meta_embs)
+    }
+
     user_df = interactions_df[interactions_df['user_id'] == user_id]
     if user_df.empty and user_library_df is not None:
         lib = user_library_df.copy()
@@ -144,7 +150,8 @@ def recommend(
         new_batch = []
         for idx in cand_idxs[0][start:search_k]:
             app_id = index_to_app[idx] if isinstance(index_to_app, list) else index_to_app[str(idx)]
-            if app_id in seen_cands:
+            app_id = int(app_id)
+            if app_id in seen_cands or app_id not in allowed_items:
                 continue
             seen_cands.add(app_id)
             candidate_ids.append(app_id)
@@ -176,20 +183,11 @@ def recommend(
             else:
                 u_emb = tables.mean_user_emb.unsqueeze(0).to(device)
         for app_id in candidate_ids:
-            idx = _app_idx(app_id)
-            if idx != 0 and idx < tables.item_emb.num_embeddings:
-                i_emb = tables.item_emb(torch.tensor([idx], device=device))
-            else:
-                i_emb = tables.mean_item_emb.unsqueeze(0).to(device)
-            if idx != 0 and idx < len(item_meta_embs):
-                i_meta = (
-                    torch.from_numpy(item_meta_embs[idx])
-                    .float()
-                    .unsqueeze(0)
-                    .to(device)
-                )
-            else:
-                i_meta = torch.zeros((1, item_meta_embs.shape[1]), device=device)
+            idx = allowed_items[app_id]
+            i_emb = tables.item_emb(torch.tensor([idx], device=device))
+            i_meta = (
+                torch.from_numpy(item_meta_embs[idx]).float().unsqueeze(0).to(device)
+            )
             feat = torch.cat([u_emb, user_meta_emb, i_emb, i_meta], dim=1)
             s = score_mlp(feat)
             scores.append(s.item())

--- a/ml/pipeline/chunk8_embeddings.py
+++ b/ml/pipeline/chunk8_embeddings.py
@@ -4,8 +4,8 @@ import torch.nn as nn
 
 class EmbeddingTables:
     def __init__(self, num_users: int, num_items: int):
-        self.user_emb = nn.Embedding(num_users, 128)
-        self.item_emb = nn.Embedding(num_items, 128)
+        self.user_emb = nn.Embedding(num_users + 1, 128, padding_idx=0)
+        self.item_emb = nn.Embedding(num_items + 1, 128, padding_idx=0)
         self.mean_user_emb = torch.zeros(128)
         self.mean_item_emb = torch.zeros(128)
 
@@ -22,14 +22,22 @@ class EmbeddingTables:
         num_users = user_state['weight'].shape[0]
         num_items = item_state['weight'].shape[0]
 
-        self.user_emb = nn.Embedding(num_users, 128).to(device)
-        self.item_emb = nn.Embedding(num_items, 128).to(device)
+        self.user_emb = nn.Embedding(num_users, 128, padding_idx=0).to(device)
+        self.item_emb = nn.Embedding(num_items, 128, padding_idx=0).to(device)
         self.user_emb.load_state_dict(user_state)
         self.item_emb.load_state_dict(item_state)
         self.mean_user_emb = torch.load(f'{path_prefix}_mean_user.pt', map_location=device)
         self.mean_item_emb = torch.load(f'{path_prefix}_mean_item.pt', map_location=device)
 
     def compute_means(self):
-        self.mean_user_emb = self.user_emb.weight.data.mean(dim=0)
-        self.mean_item_emb = self.item_emb.weight.data.mean(dim=0)
+        # Skip padding row at index 0 for users and items
+        if self.user_emb.num_embeddings > 1:
+            self.mean_user_emb = self.user_emb.weight.data[1:].mean(dim=0)
+        else:
+            self.mean_user_emb = torch.zeros_like(self.mean_user_emb)
+
+        if self.item_emb.num_embeddings > 1:
+            self.mean_item_emb = self.item_emb.weight.data[1:].mean(dim=0)
+        else:
+            self.mean_item_emb = torch.zeros_like(self.mean_item_emb)
 


### PR DESCRIPTION
## Summary
- reserve index 0 in both user and item embedding tables and exclude the padding row when computing mean embeddings
- map user and item ids to embedding indices with a +1 offset and pad precomputed metadata tensors accordingly during training
- mirror the padded indexing for users and items in the inference pipeline
- derive user metadata size from actual profiles and load that dimension from saved weights at inference

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6ebeb51b4832f8231db531ee9c7d2