### PR TITLE
Use margin-based softplus loss

### DIFF
--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Set, Tuple
 import numpy as np
 import pandas as pd
 import torch
+import torch.nn.functional as F
 from torch.optim import AdamW
 from torch.nn.utils import clip_grad_norm_
 from transformers import get_cosine_schedule_with_warmup
@@ -52,11 +53,14 @@ def train_model(
     num_epochs: int | None = None,
     batch_size: int = 256,
     data_dir: str | None = None,
+    margin: float = 1.0,
 ) -> None:
     """Train embedding models with pairwise ranking.
 
     The function precomputes item and user metadata, supports optional
     adaptive early stopping and runs on CPU or GPU depending on availability.
+    A softplus loss with an explicit margin encourages positive scores to
+    exceed negative scores by ``margin``.
     """
 
     if data_dir is None:
@@ -311,8 +315,8 @@ def train_model(
                 s_pos = score_mlp(x_pos, u_batch, pos_idx)
                 s_neg = score_mlp(x_neg, u_batch, neg_idx)
 
-                diff = torch.clamp(s_pos - s_neg, -30.0, 30.0)
-                loss = -torch.log(torch.sigmoid(diff)).mean()
+                diff = s_pos - s_neg
+                loss = F.softplus(margin - diff).mean()
                 losses.append(loss)
             if not losses:
                 continue

--- a/ml/pipeline/train_pipeline.py
+++ b/ml/pipeline/train_pipeline.py
@@ -41,6 +41,12 @@ def main():
         help="override NUM_EPOCHS env for chunk10 training",
     )
     parser.add_argument(
+        "--margin",
+        type=float,
+        default=None,
+        help="override margin for chunk10 pairwise loss",
+    )
+    parser.add_argument(
         "--svd_dim",
         type=int,
         default=None,
@@ -62,6 +68,11 @@ def main():
     epochs = int(epochs_env) if epochs_env else None
     if args.epochs is not None:
         epochs = max(1, int(args.epochs))
+
+    margin_env = os.getenv("MARGIN")
+    margin = float(margin_env) if margin_env else 1.0
+    if args.margin is not None:
+        margin = float(args.margin)
 
     games_df_cache = {}
 
@@ -87,7 +98,7 @@ def main():
         ("chunk4", lambda: chunk4_text_embeddings.run_text_embeddings(load_games_df())),
         ("chunk5", chunk5_item_meta.run_item_meta_embedding),
         ("chunk6", chunk6_faiss.build_faiss_indices),
-        ("chunk10", lambda: chunk10_train.train_model(num_epochs=epochs)),
+        ("chunk10", lambda: chunk10_train.train_model(num_epochs=epochs, margin=margin)),
     ]
 
     # Determine which chunk(s) to run


### PR DESCRIPTION
## Summary
- switch pairwise training to a margin-based `softplus` loss and drop manual clamping
- expose configurable loss margin via `train_pipeline` CLI and env var

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6fc446f00832fbbe03c59742f4f33