### PR TITLE
Normalize user tag profile

### DIFF
--- a/ml/pipeline/chunk7_user_profile.py
+++ b/ml/pipeline/chunk7_user_profile.py
@@ -70,6 +70,11 @@ def compute_user_meta_raw(
     else:
         user_tag_profile = global_tag_mean.astype(np.float32).copy()
 
+    norm = float(np.linalg.norm(user_tag_profile))
+    if norm == 0:
+        norm = 1e-8
+    user_tag_profile = (user_tag_profile / norm).astype(np.float32)
+
     recent_cut = now - timedelta(days=30)
     recent_play = interactions_df[
         (interactions_df['user_id']==user_id) & (interactions_df['playtime_2weeks']>0)


### PR DESCRIPTION
## Summary
- Normalize averaged user tag vectors in `compute_user_meta_raw` with L2 norm and epsilon for stability

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c75a7b3d44832fb064408b22e10ab5