### PR TITLE
Incorporate user-item dot product in ScoreMLP

### DIFF
--- a/ml/pipeline/chunk10_train.py
+++ b/ml/pipeline/chunk10_train.py
@@ -198,7 +198,7 @@ def train_model(
                     item_meta = item_meta_embs[idx].unsqueeze(0)
                     x = torch.cat([u_emb, user_meta_emb, item_emb, item_meta], dim=1)
                     item_idx_tensor = torch.tensor([idx], dtype=torch.long, device=device)
-                    scores.append(score_mlp(x, u_idx_tensor, item_idx_tensor).item())
+                    scores.append(score_mlp(x, u_emb, item_emb, u_idx_tensor, item_idx_tensor).item())
                     label = int(
                         (row["playtime_forever"] > 0)
                         or (row["playtime_2weeks"] > 0)
@@ -240,7 +240,7 @@ def train_model(
                     um_rep = user_meta_emb.repeat(len(candidates), 1)
                     x = torch.cat([u_rep, um_rep, item_embs, item_meta], dim=1)
                     u_batch = torch.full((len(candidates),), u_idx, dtype=torch.long, device=device)
-                    cand_scores = score_mlp(x, u_batch, idx_tensor).view(-1).cpu().numpy()
+                    cand_scores = score_mlp(x, u_rep, item_embs, u_batch, idx_tensor).view(-1).cpu().numpy()
                     cand_labels = np.zeros(len(candidates), dtype=int)
                     cand_labels[0] = 1
                     ranking = np.argsort(-cand_scores)
@@ -354,10 +354,14 @@ def train_model(
                     (len(pos_list) * neg_per_pos,), u_idx, dtype=torch.long, device=device
                 )
 
-                s_pos = score_mlp(x_pos, u_batch_pos, pos_idx)
-                s_neg = score_mlp(x_neg, u_batch_neg, neg_idx.view(-1)).view(
-                    len(pos_list), neg_per_pos
-                )
+                s_pos = score_mlp(x_pos, u_rep, pos_emb, u_batch_pos, pos_idx)
+                s_neg = score_mlp(
+                    x_neg,
+                    u_rep_neg,
+                    neg_emb.view(len(pos_list) * neg_per_pos, -1),
+                    u_batch_neg,
+                    neg_idx.view(-1),
+                ).view(len(pos_list), neg_per_pos)
 
                 diff = s_pos.unsqueeze(1) - s_neg
                 loss = F.softplus(margin - diff).mean()

--- a/ml/pipeline/chunk11_inference.py
+++ b/ml/pipeline/chunk11_inference.py
@@ -187,7 +187,7 @@ def recommend(
             item_idx_tensor = torch.tensor([idx], dtype=torch.long, device=device)
             i_meta = torch.from_numpy(item_meta_embs[idx]).float().unsqueeze(0).to(device)
             feat = torch.cat([u_emb, user_meta_emb, i_emb, i_meta], dim=1)
-            s = score_mlp(feat, u_idx_tensor, item_idx_tensor)
+            s = score_mlp(feat, u_emb, i_emb, u_idx_tensor, item_idx_tensor)
             scores.append(s.item())
             scored_ids.append(app_id)
 

--- a/ml/pipeline/chunk9_model.py
+++ b/ml/pipeline/chunk9_model.py
@@ -36,7 +36,16 @@ class ScoreMLP(nn.Module):
         self.bn3 = nn.LayerNorm(256)
         self.fc4 = nn.Linear(256, 1)
 
-    def forward(self, x, user_idx: torch.LongTensor | None = None, item_idx: torch.LongTensor | None = None):
+    def forward(
+        self,
+        x,
+        user_emb: torch.Tensor,
+        item_emb: torch.Tensor,
+        user_idx: torch.LongTensor | None = None,
+        item_idx: torch.LongTensor | None = None,
+    ):
+        dp = (user_emb * item_emb).sum(dim=1, keepdim=True)
+
         h = self.fc1(x)
         h = self.bn1(h)
         h = F.relu(h)
@@ -54,6 +63,7 @@ class ScoreMLP(nn.Module):
         h = F.relu(h)
         h = F.dropout(h, p=0.3, training=self.training)
         out = self.fc4(h)
+        out = out + dp
 
         if user_idx is not None:
             out = out + self.user_bias(user_idx)


### PR DESCRIPTION
## Summary
- Integrate explicit user-item dot product interaction into `ScoreMLP` and merge it with the MLP output
- Update training and inference routines to pass embeddings for the new interaction term

## Testing
- `python -m py_compile ml/pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c75e445e00832fa452cdd489740163