### PR TITLE
Optimize ML build caching and reuse

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       - dev     # <--- only spin this up for dev
 
   ml-extract:
+    image: steam-game-recommender-ml
     build:
       context: ./ml
       dockerfile: Dockerfile
@@ -106,6 +107,7 @@ services:
       - backend-network
     volumes:
       - ./:/app
+      - hf-cache:/root/.cache/huggingface
     gpus: all
     profiles: ["extract"]
     command: >
@@ -116,6 +118,7 @@ services:
       "
 
   ml-train:
+    image: steam-game-recommender-ml
     build:
       context: ./ml
       dockerfile: Dockerfile
@@ -128,12 +131,14 @@ services:
       - backend-network
     volumes:
       - ./:/app
+      - hf-cache:/root/.cache/huggingface
     gpus: all
     profiles: ["train"]
     working_dir: /app
     command: python -m ml.pipeline.train_pipeline ${RUN_CHUNK:+--chunk $RUN_CHUNK} --start ${START_CHUNK:-1}
       
   recommender:
+    image: steam-game-recommender-ml
     build:
       context: ./ml
       dockerfile: Dockerfile
@@ -144,6 +149,7 @@ services:
       - API_KEY=${API_KEY}
     volumes:
       - .:/app
+      - hf-cache:/root/.cache/huggingface
     gpus: all
     ports:
       - "8001:8001"
@@ -163,6 +169,7 @@ services:
 
 volumes:
   frontend_node_modules:
+  hf-cache:
   
 networks:
   backend-network:

--- a/ml/.dockerignore
+++ b/ml/.dockerignore
@@ -1,0 +1,11 @@
+# Exclude large or generated artifacts from the build context
+models/
+data/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.ipynb_checkpoints
+.env
+.DS_Store
+*.log

--- a/ml/Dockerfile
+++ b/ml/Dockerfile
@@ -1,25 +1,29 @@
+# syntax=docker/dockerfile:1.4
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 
 WORKDIR /app
 
-# Install Python and basic tools
+# Install Python and system dependencies once so Docker can cache the layer
 RUN apt-get update && \
     apt-get install -y python3 python3-pip git && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies first (cache this layer)
-COPY requirements.txt .
-RUN pip3 install --no-cache-dir -r requirements.txt
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    HF_HOME=/root/.cache/huggingface \
+    TRANSFORMERS_CACHE=/root/.cache/huggingface
 
-# Download HuggingFace model early to cache it
-RUN mkdir -p /root/.cache/huggingface && \
+# Install Python dependencies (cached via BuildKit)
+COPY requirements.txt ./
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install -r requirements.txt
+
+# Prime the Hugging Face cache without baking the weights into the image
+RUN --mount=type=cache,target=/root/.cache/huggingface \
     python3 -c "from transformers import AutoTokenizer, AutoModel; AutoTokenizer.from_pretrained('sentence-transformers/all-MiniLM-L6-v2'); AutoModel.from_pretrained('sentence-transformers/all-MiniLM-L6-v2')"
 
-# Install fastapi to connect between backend and recommend_games
-RUN pip install fastapi uvicorn scikit-learn torch joblib
-
-# Now copy your actual code (only if needed)
+# Now copy the application code
 COPY . .
 
-# Entrypoint is defined by docker-compose
+# Entrypoint/command are defined per docker-compose service


### PR DESCRIPTION
## Summary
- enable BuildKit caching in the ML Dockerfile so dependency and model downloads are reused between builds
- avoid copying large training artifacts into the image by excluding them from the build context
- share the same ML image between compose services and persist the Hugging Face cache via a named volume

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c760d0ed8c832f90b53addd6c156bb